### PR TITLE
fix #28 - feat: Create a pre-commit hook to force signed commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright 2026 The Serverless Workflow Specification Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This hook checks that the commit message includes a "Signed-off-by" line.
+
+COMMIT_MSG=$(cat "$1")
+
+# Check for Signed-off-by line
+if ! echo "$COMMIT_MSG" | grep -qE '^Signed-off-by: .+ <.+@.+>'; then
+    cat <<EOF
+ERROR: Commit message is missing DCO sign-off.
+
+This project requires all commits to include a Developer Certificate
+of Origin (DCO) sign-off. To sign your commit, use:
+
+  git commit -s -m "Your commit message"
+EOF
+    exit 1
+fi
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "serverless-workflow-editor",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "serverless-workflow-editor",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "husky": "^9.1.7"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "serverless-workflow-editor",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CNCF Serverless Workflow Specification Visual Editor",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/serverlessworkflow/editor.git"
+  },
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/28

### Description

Create a pre-commit hook to check if the commit is correctly signed, and if not, reject the local commit with a clear message.

### Motivation

Developers can forget to sign their commits, or a new contributor may not be aware of this mandatory setting.
When we create a PR with a non-signed commit, the DCO CI will fail, and we need to rebase all the commits, resign them and force-push, which is a bit time-consuming.

### Proposed Implementation

Create a pre-commit hook to check the current commit when `git commit ...` is executed  

### Definition of Done

- [ ] Implementation: Fully implemented according to the Serverless Workflow spec.
- [ ] Unit Tests: Comprehensive unit tests are included and passing.
- [ ] Integration Tests: Verified within the monorepo and target environments (Web/VS Code).
- [ ] Documentation: Updated README.md, ADRs, or official docs.
- [ ] Performance: No significant regression in editor responsiveness.
- [ ] Accessibility: UI changes comply with accessibility standards.

### Steps to test:
- Create a file
- run:
```
git add .
git commit -m "test"
```
- The commit is rejected with a clear message