### PR TITLE
ci: add workflow to sync issues to a target GitHub project

### DIFF
--- a/.github/workflows/sync-issues-to-project.md
+++ b/.github/workflows/sync-issues-to-project.md
@@ -28,9 +28,9 @@ are closed, and optionally imports pre-existing repo issues on demand.
 
 | Event | Action |
 |---|---|
-| Issue opened | Issue is added to the target project; initial field values are applied (skipped if `GH_SYNC_ENABLED=false` or `off`) |
-| Issue closed | Project item Status is updated to the configured close status (skipped if `GH_SYNC_ENABLED=false` or `off`) |
-| `workflow_dispatch` | If `GH_IMPORT_EXISTING_ISSUES=true`, imports all open repo issues not yet in the project with initial field values applied |
+| Issue opened | Issue is added to the target project; initial field values are applied (skipped if `PSYNC_ENABLED=false` or `off`) |
+| Issue closed | Project item Status is updated to the configured close status (skipped if `PSYNC_ENABLED=false` or `off`) |
+| `workflow_dispatch` | If `PSYNC_IMPORT_EXISTING=true`, imports all open repo issues not yet in the project with initial field values applied |
 
 The project item is natively linked to the source issue — no custom fields are
 needed. Clicking the item in the project board opens the original issue.
@@ -47,7 +47,7 @@ Required scopes:
 - `project` — read/write access to GitHub Projects v2
 - `read:org` — required to resolve the org's project by number
 - `repo` (private repos) or `public_repo` (public repos) — required only if
-  `GH_ISSUE_INITIAL_VALUES` includes `Assignees=...`, as the workflow calls the
+  `PSYNC_INITIAL_VALUES` includes `Assignees=...`, as the workflow calls the
   REST API to add assignees directly to the source repo issue
 
 > Classic PATs only. Fine-grained PATs do not yet support Projects v2 mutations.
@@ -56,39 +56,43 @@ Required scopes:
 
 Go to **Repo → Settings → Secrets and variables → Actions → Secrets**:
 
-| Name | Value |
-|---|---|
-| `GH_PAT_TOKEN` | The PAT created above |
+| Name | Fallback name | Value |
+|---|---|---|
+| `PSYNC_PAT` | `GH_PAT_TOKEN` | The PAT created above |
 
 ### 3. Add the variables
 
 Go to **Repo → Settings → Secrets and variables → Actions → Variables**:
 
-| Name | Required | Default | Example |
-|---|---|---|---|
-| `GH_TARGET_PROJECT` | yes | — | `my-org:1` |
-| `GH_ISSUE_INITIAL_VALUES` | no | — | `Status=Backlog, Area=Tooling, Assignees=user1` |
-| `GH_ISSUE_CLOSE_STATUS` | no | `Done` | `Done` |
-| `GH_SYNC_ENABLED` | no | `true` | `false` |
-| `GH_IMPORT_EXISTING_ISSUES` | no | `false` | `true` |
-| `GH_AUTHORS_FILTER` | no | — | `user1, user2` |
+| Name | Fallback name | Required | Default | Description | Example |
+|---|---|---|---|---|---|
+| `PSYNC_TARGET` | `GH_TARGET_PROJECT` | yes | — | Target project in `org:project_number` format | `my-org:1` |
+| `PSYNC_INITIAL_VALUES` | `GH_ISSUE_INITIAL_VALUES` | no | — | Comma-separated `field=value` pairs applied to new project items | `Status=Backlog, Area=Tooling, Assignees=user1` |
+| `PSYNC_CLOSE_STATUS` | `GH_ISSUE_CLOSE_STATUS` | no | `Done` | Status option name set on the project item when the issue is closed | `Done` |
+| `PSYNC_ENABLED` | `GH_SYNC_ENABLED` | no | `true` | Set to `false` or `off` to pause syncing without removing the workflow | `false` |
+| `PSYNC_IMPORT_EXISTING` | `GH_IMPORT_EXISTING_ISSUES` | no | `false` | Set to `true` and trigger manually to bulk-import all open issues not yet in the project | `true` |
+| `PSYNC_AUTHORS_FILTER` | `GH_AUTHORS_FILTER` | no | — | Comma-separated list of GitHub usernames; only issues opened by these users are synced. Empty means all authors are included | `user1, user2` |
+
+> **Backward compatibility** — the workflow reads the `PSYNC_*` name first and
+> falls back to the `GH_*` name when the new variable is not set. Existing setups
+> using the old names continue to work without changes.
 
 The project number is visible in the project URL:
 `https://github.com/orgs/<org>/projects/<number>`
 
-**`GH_SYNC_ENABLED`** — set to `false` or `off` to pause syncing without removing
+**`PSYNC_ENABLED`** — set to `false` or `off` to pause syncing without removing
 the workflow. `workflow_dispatch` runs (e.g. for importing) are not affected.
 
-**`GH_AUTHORS_FILTER`** — comma-separated list of GitHub usernames. When set, only
+**`PSYNC_AUTHORS_FILTER`** — comma-separated list of GitHub usernames. When set, only
 issues created by one of the listed authors are synced to the target project. If
 unset or empty, all authors are included.
 
-**`GH_IMPORT_EXISTING_ISSUES`** — set to `true` and trigger the workflow manually
+**`PSYNC_IMPORT_EXISTING`** — set to `true` and trigger the workflow manually
 via **Actions → Run workflow** to import all open repo issues not already in the
-project. The same `GH_ISSUE_INITIAL_VALUES` rules apply. Issues already in the
+project. The same `PSYNC_INITIAL_VALUES` rules apply. Issues already in the
 project are skipped. The run prints a summary: `Imported: N, Failed: N`.
 
-#### `GH_ISSUE_INITIAL_VALUES` format
+#### `PSYNC_INITIAL_VALUES` format
 
 Comma-separated `field=value` pairs. Field names must match the project field
 names exactly (case-sensitive). Example:
@@ -110,7 +114,7 @@ Supported field types:
 ### 4. Ensure the target project has a Status field
 
 The workflow looks for a **single-select field named exactly `Status`**. The
-option names used by `GH_ISSUE_INITIAL_VALUES` and `GH_ISSUE_CLOSE_STATUS` must
+option names used by `PSYNC_INITIAL_VALUES` and `PSYNC_CLOSE_STATUS` must
 exist in the project (case-sensitive).
 
 Default options required unless overridden:
@@ -126,7 +130,7 @@ Default options required unless overridden:
 - **Sub-issues are not synced** — GitHub does not emit webhook events for
   sub-issues; only top-level issues trigger the `issues` event.
 - **Status field name is hardcoded** — the field must be named `Status`.
-- **Number and date fields** in `GH_ISSUE_INITIAL_VALUES` are not supported;
+- **Number and date fields** in `PSYNC_INITIAL_VALUES` are not supported;
   only single-select and text fields.
 
 ---
@@ -135,8 +139,8 @@ Default options required unless overridden:
 
 ### `gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable`
 
-The `GH_PAT_TOKEN` secret is not set or is empty. Verify it exists under
-**Repo → Settings → Secrets and variables → Actions → Secrets**.
+Neither `PSYNC_PAT` nor `GH_PAT_TOKEN` is set or both are empty. Verify that at
+least one exists under **Repo → Settings → Secrets and variables → Actions → Secrets**.
 
 ### `Error: Process completed with exit code 1` on the GraphQL steps
 
@@ -158,7 +162,7 @@ gh api graphql -f query='
 Common causes:
 - The PAT does not have access to the target org's project
 - The project number is wrong
-- The org name in `GH_TARGET_PROJECT` has a typo
+- The org name in `PSYNC_TARGET` (or `GH_TARGET_PROJECT`) has a typo
 
 ### Item not found on close (`item_id` is empty)
 
@@ -166,18 +170,18 @@ If the issue is not already in the project when it is closed (e.g., it was opene
 
 If the close path still fails, likely causes are:
 - The PAT lacks `project` write access to the target org's project
-- The project ID lookup failed (check `GH_TARGET_PROJECT` format and PAT scopes)
+- The project ID lookup failed (check `PSYNC_TARGET` (or `GH_TARGET_PROJECT`) format and PAT scopes)
 
 ### Status not updated on close
 
 Verify the target project has:
 - A single-select field named exactly `Status`
-- An option matching the value of `GH_ISSUE_CLOSE_STATUS` (default: `Done`)
+- An option matching the value of `PSYNC_CLOSE_STATUS` (or `GH_ISSUE_CLOSE_STATUS`, default: `Done`)
 
 Field and option names are case-sensitive.
 
 ### Field not found warning in `Set initial field values`
 
 The step prints `Warning: field '<name>' not found, skipping.` when a key in
-`GH_ISSUE_INITIAL_VALUES` does not match any field in the project. Check for
+`PSYNC_INITIAL_VALUES` (or `GH_ISSUE_INITIAL_VALUES`) does not match any field in the project. Check for
 typos or extra spaces in the variable value.

--- a/.github/workflows/sync-issues-to-project.yml
+++ b/.github/workflows/sync-issues-to-project.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Parse target project
         id: parse
         run: |
-          VALUE="${{ vars.GH_TARGET_PROJECT }}"
+          VALUE="${{ vars.PSYNC_TARGET || vars.GH_TARGET_PROJECT }}"
           if ! [[ "$VALUE" =~ ^[^:]+:[0-9]+$ ]]; then
-            echo "Error: GH_TARGET_PROJECT='$VALUE' is invalid. Expected format: org:project_number (e.g. kubesmarts:1)"
+            echo "Error: PSYNC_TARGET (or GH_TARGET_PROJECT) value '$VALUE' is invalid. Expected format: org:project_number (e.g. my-org:1)"
             exit 1
           fi
           ORG="${VALUE%%:*}"
@@ -42,7 +42,7 @@ jobs:
         id: author_filter
         if: github.event_name == 'issues'
         run: |
-          FILTER="${{ vars.GH_AUTHORS_FILTER }}"
+          FILTER="${{ vars.PSYNC_AUTHORS_FILTER || vars.GH_AUTHORS_FILTER }}"
           if [ -z "$FILTER" ]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -51,15 +51,15 @@ jobs:
           if echo "$FILTER" | tr ',' '\n' | xargs -I{} echo {} | xargs | tr ' ' '\n' | grep -qx "$AUTHOR"; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Issue author '$AUTHOR' is not in GH_AUTHORS_FILTER — skipping."
+            echo "Issue author '$AUTHOR' is not in PSYNC_AUTHORS_FILTER — skipping."
             echo "allowed=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get project ID
         id: project
-        if: github.event_name == 'workflow_dispatch' || (vars.GH_SYNC_ENABLED != 'false' && vars.GH_SYNC_ENABLED != 'off' && steps.author_filter.outputs.allowed != 'false')
+        if: github.event_name == 'workflow_dispatch' || ((vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'false' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'off' && steps.author_filter.outputs.allowed != 'false')
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PSYNC_PAT || secrets.GH_PAT_TOKEN }}
         run: |
           PROJECT_ID=$(gh api graphql -f query='
             query($org: String!, $number: Int!) {
@@ -73,18 +73,18 @@ jobs:
             -F number=${{ steps.parse.outputs.number }} \
             --jq '.data.organization.projectV2.id')
           if [ -z "$PROJECT_ID" ] || [ "$PROJECT_ID" = "null" ]; then
-            echo "Error: could not resolve project ID for '${{ steps.parse.outputs.org }}' project number ${{ steps.parse.outputs.number }}. Check GH_TARGET_PROJECT and that GH_PAT_TOKEN has access to the target org's project."
+            echo "Error: could not resolve project ID for '${{ steps.parse.outputs.org }}' project number ${{ steps.parse.outputs.number }}. Check PSYNC_TARGET (or GH_TARGET_PROJECT) and that PSYNC_PAT (or GH_PAT_TOKEN) has access to the target org's project."
             exit 1
           fi
           echo "id=$PROJECT_ID" >> "$GITHUB_OUTPUT"
 
       - name: Import existing repo issues
-        if: github.event_name == 'workflow_dispatch' && vars.GH_IMPORT_EXISTING_ISSUES == 'true'
+        if: github.event_name == 'workflow_dispatch' && (vars.PSYNC_IMPORT_EXISTING || vars.GH_IMPORT_EXISTING_ISSUES) == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PSYNC_PAT || secrets.GH_PAT_TOKEN }}
         run: |
           PROJECT_ID="${{ steps.project.outputs.id }}"
-          INITIAL_VALUES="${{ vars.GH_ISSUE_INITIAL_VALUES }}"
+          INITIAL_VALUES="${{ vars.PSYNC_INITIAL_VALUES || vars.GH_ISSUE_INITIAL_VALUES }}"
 
           # Fetch project fields once if initial values are configured
           FIELDS_JSON="[]"
@@ -114,7 +114,7 @@ jobs:
               --jq '.data.node.fields.nodes')
           fi
 
-          # Helper: apply GH_ISSUE_INITIAL_VALUES to a project item
+          # Helper: apply PSYNC_INITIAL_VALUES (or GH_ISSUE_INITIAL_VALUES) to a project item
           apply_fields() {
             local ITEM_ID="$1"
             local ISSUE_NUMBER="$2"
@@ -175,8 +175,8 @@ jobs:
           REPO_ISSUES=$(gh api "repos/${{ github.repository }}/issues" \
             --paginate | jq -s '[ .[][] | select(.pull_request == null) | {node_id, number, author: .user.login} ]')
 
-          # Filter by author if GH_AUTHORS_FILTER is set
-          AUTHORS_FILTER="${{ vars.GH_AUTHORS_FILTER }}"
+          # Filter by author if PSYNC_AUTHORS_FILTER (or GH_AUTHORS_FILTER) is set
+          AUTHORS_FILTER="${{ vars.PSYNC_AUTHORS_FILTER || vars.GH_AUTHORS_FILTER }}"
           if [ -n "$AUTHORS_FILTER" ]; then
             AUTHORS_JSON=$(echo "$AUTHORS_FILTER" | tr ',' '\n' | xargs -I{} echo {} | jq -R . | jq -s '.')
             REPO_ISSUES=$(echo "$REPO_ISSUES" | jq --argjson authors "$AUTHORS_JSON" \
@@ -263,9 +263,9 @@ jobs:
 
       - name: Add issue to project
         id: add_item
-        if: github.event.action == 'opened' && vars.GH_SYNC_ENABLED != 'false' && vars.GH_SYNC_ENABLED != 'off' && steps.author_filter.outputs.allowed != 'false'
+        if: github.event.action == 'opened' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'false' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'off' && steps.author_filter.outputs.allowed != 'false'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PSYNC_PAT || secrets.GH_PAT_TOKEN }}
         run: |
           ITEM_ID=$(gh api graphql -f query='
             mutation($projectId: ID!, $contentId: ID!) {
@@ -275,7 +275,7 @@ jobs:
             }' \
             -f projectId="${{ steps.project.outputs.id }}" \
             -f contentId="${{ github.event.issue.node_id }}" \
-            --jq '.data.addProjectV2ItemById.item.id')
+            --jq '.data.addProjectV2ItemById.item.id' || true)
           if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
             echo "Error: failed to add issue to project — item ID is empty or null. The issue may already exist in the project or the PAT may lack access."
             exit 1
@@ -283,11 +283,11 @@ jobs:
           echo "item_id=$ITEM_ID" >> "$GITHUB_OUTPUT"
 
       - name: Set initial field values
-        if: github.event.action == 'opened' && vars.GH_SYNC_ENABLED != 'false' && vars.GH_SYNC_ENABLED != 'off' && steps.author_filter.outputs.allowed != 'false'
+        if: github.event.action == 'opened' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'false' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'off' && steps.author_filter.outputs.allowed != 'false'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PSYNC_PAT || secrets.GH_PAT_TOKEN }}
         run: |
-          INITIAL_VALUES="${{ vars.GH_ISSUE_INITIAL_VALUES }}"
+          INITIAL_VALUES="${{ vars.PSYNC_INITIAL_VALUES || vars.GH_ISSUE_INITIAL_VALUES }}"
           [ -z "$INITIAL_VALUES" ] && exit 0
 
           # Fetch all project fields (single-select and text)
@@ -383,11 +383,11 @@ jobs:
 
       - name: Get item ID and close Status option ID
         id: find_item
-        if: github.event.action == 'closed' && vars.GH_SYNC_ENABLED != 'false' && vars.GH_SYNC_ENABLED != 'off' && steps.author_filter.outputs.allowed != 'false'
+        if: github.event.action == 'closed' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'false' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'off' && steps.author_filter.outputs.allowed != 'false'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PSYNC_PAT || secrets.GH_PAT_TOKEN }}
         run: |
-          CLOSE_STATUS="${{ vars.GH_ISSUE_CLOSE_STATUS }}"
+          CLOSE_STATUS="${{ vars.PSYNC_CLOSE_STATUS || vars.GH_ISSUE_CLOSE_STATUS }}"
           CLOSE_STATUS="${CLOSE_STATUS:-Done}"
 
           # Fetch Status field info once
@@ -422,7 +422,7 @@ jobs:
             '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == $status) | .id // empty')
 
           if [ -z "$CLOSE_OPTION_ID" ]; then
-            echo "Error: Status option '$CLOSE_STATUS' not found in the target project. Check the GH_ISSUE_CLOSE_STATUS variable (default: Done) — value must match a Status option exactly (case-sensitive)."
+            echo "Error: Status option '$CLOSE_STATUS' not found in the target project. Check PSYNC_CLOSE_STATUS (or GH_ISSUE_CLOSE_STATUS, default: Done) — value must match a Status option exactly (case-sensitive)."
             exit 1
           fi
 
@@ -500,9 +500,9 @@ jobs:
           echo "close_option_id=$CLOSE_OPTION_ID" >> "$GITHUB_OUTPUT"
 
       - name: Set item close Status
-        if: github.event.action == 'closed' && vars.GH_SYNC_ENABLED != 'false' && vars.GH_SYNC_ENABLED != 'off' && steps.author_filter.outputs.allowed != 'false'
+        if: github.event.action == 'closed' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'false' && (vars.PSYNC_ENABLED || vars.GH_SYNC_ENABLED) != 'off' && steps.author_filter.outputs.allowed != 'false'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PSYNC_PAT || secrets.GH_PAT_TOKEN }}
         run: |
           ITEM_ID="${{ steps.find_item.outputs.item_id }}"
           OPTION_ID="${{ steps.find_item.outputs.close_option_id }}"


### PR DESCRIPTION
## Summary

Renames all variables and secrets used by `sync-issues-to-project.yml` and `sync-issues-to-project.md` from the generic `GH_` prefix to `PSYNC_`, with full backward compatibility — the workflow reads `PSYNC_*` first and falls back to the corresponding `GH_*` name so existing setups continue to work without changes.

## Variable / secret mapping

| New name | Fallback | Description |
|---|---|---|
| \`PSYNC_PAT\` | \`GH_PAT_TOKEN\` | PAT with \`project\` and \`read:org\` scopes |
| \`PSYNC_TARGET\` | \`GH_TARGET_PROJECT\` | Target project in \`org:project_number\` format |
| \`PSYNC_ENABLED\` | \`GH_SYNC_ENABLED\` | Set to \`false\`/\`off\` to pause syncing |
| \`PSYNC_INITIAL_VALUES\` | \`GH_ISSUE_INITIAL_VALUES\` | Field values applied to new project items |
| \`PSYNC_CLOSE_STATUS\` | \`GH_ISSUE_CLOSE_STATUS\` | Status set when an issue is closed (default: \`Done\`) |
| \`PSYNC_IMPORT_EXISTING\` | \`GH_IMPORT_EXISTING_ISSUES\` | Bulk-import existing open issues on manual trigger |
| \`PSYNC_AUTHORS_FILTER\` | \`GH_AUTHORS_FILTER\` | Only sync issues from these GitHub usernames |

Closes #39