### PR TITLE
fix #30 - feat: Add GitHub Action to publish Storybook preview for every PR via Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <!--
    Copyright 2021-Present The Serverless Workflow Specification Authors
-  
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-  
+
    http://www.apache.org/licenses/LICENSE-2.0
-  
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,12 +15,14 @@
 -->
 
 # editor
+
 CNCF Serverless Workflow Specification Visual Editor
 
 ## Prerequisites
 
 To build and run the editor locally, you will need:
-- **Node.js 22** (current LTS version; see https://nodejs.org/)
+
+- **Node.js 24** (current LTS version; see https://nodejs.org/)
 - **pnpm 10.31.0**
 
 ## Building the Project

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CNCF Serverless Workflow Specification Visual Editor
 
 To build and run the editor locally, you will need:
 
-- **Node.js 24** (current LTS version; see https://nodejs.org/)
+- **Node.js 22** (current LTS version; see https://nodejs.org/)
 - **pnpm 10.31.0**
 
 ## Building the Project

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,7 @@
     set -e
     PREVIEW_PACKAGE_NAME='@serverlessworkflow/diagram-editor'
     pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME" || { echo "Skip build: No changes detected"; exit 0; }
-    echo "Building ${PREVIEW_PACKAGE_NAME}####################################################################################################"
+    echo "Building ${PREVIEW_PACKAGE_NAME}##################################################"
     pnpm -F "${PREVIEW_PACKAGE_NAME}..." build:dev
     pnpm -F "$PREVIEW_PACKAGE_NAME" build:storybook
   """

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,12 +14,16 @@
 # limitations under the License.
 #
 
+[build.environment]
+  NODE_VERSION = "24"
+
 [build]
   command = """
-    pnpm install --frozen-lockfile &&
-    pnpm -F '...[origin/main]' exec pnpm pkg get name | grep -q '\"@serverlessworkflow/diagram-editor\"' ||
-    exit 0
-    pnpm -F @serverlessworkflow/diagram-editor... build:dev &&
-    pnpm -F @serverlessworkflow/diagram-editor build:storybook
+    set -e
+    PREVIEW_PACKAGE_NAME='@serverlessworkflow/diagram-editor'
+    pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME" || { echo "Skip build: No changes detected"; exit 0; }
+    echo "Building ${PREVIEW_PACKAGE_NAME}####################################################################################################"
+    pnpm -F "${PREVIEW_PACKAGE_NAME}..." build:dev
+    pnpm -F "$PREVIEW_PACKAGE_NAME" build:storybook
   """
   publish = "packages/serverless-workflow-diagram-editor/dist-storybook"

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,7 +27,7 @@
   """
   publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
   ignore = """
-    set -e
+    set -e -o pipefail
     git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
     npm i -g "pnpm@$PNPM_VERSION"
     ! pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,6 @@
   publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
   ignore = """
     set -e
-    pnpm i -g "pnpm@$PNPM_VERSION"
+    npm i -g "pnpm@$PNPM_VERSION"
     ! pnpm -F '...[origin/issue-30-feat-Add-GitHub-Action-to-publish-Storybook-preview-for-every-PR-via-netlify]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
   """

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,25 @@
-[build]
-  command = "pnpm install --frozen-lockfile && pnpm -F @serverlessworkflow/diagram-editor... build:dev && pnpm -F @serverlessworkflow/diagram-editor build:storybook"
-  publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
+#
+# Copyright 2021-Present The Serverless Workflow Specification Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-  # Ignore publishing if @serverlessworkflow/diagram-editor and its dependencies have no changes
-  ignore = "! pnpm -F '...[origin/main]' exec pnpm pkg get name | grep -q '\"@serverlessworkflow/diagram-editor\"'"
+[build]
+  command = """
+    pnpm install --frozen-lockfile &&
+    pnpm -F '...[origin/main]' exec pnpm pkg get name | grep -q '\"@serverlessworkflow/diagram-editor\"' ||
+    exit 0
+    pnpm -F @serverlessworkflow/diagram-editor... build:dev &&
+    pnpm -F @serverlessworkflow/diagram-editor build:storybook
+  """
+  publish = "packages/serverless-workflow-diagram-editor/dist-storybook"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pnpm install --frozen-lockfile && pnpm build:storybook"
+  command = "pnpm install --frozen-lockfile && pnpm -F @serverlessworkflow/diagram-editor... build:dev && pnpm -F @serverlessworkflow/diagram-editor build:storybook"
   publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
 
   # Ignore publishing if @serverlessworkflow/diagram-editor and its dependencies have no changes

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build:storybook"
+  publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
+
+  # Ignore publishing if @serverlessworkflow/diagram-editor and its dependencies have no changes
+  ignore = "! pnpm -F '...[origin/main]' exec pnpm pkg get name | grep -q '\"@serverlessworkflow/diagram-editor\"'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,6 +28,7 @@
   publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
   ignore = """
     set -e
+    git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
     npm i -g "pnpm@$PNPM_VERSION"
     ! pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
   """

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,14 +16,18 @@
 
 [build.environment]
   NODE_VERSION = "24"
+  PNPM_VERSION = "10.31.0"
+  PREVIEW_PACKAGE_NAME = "@serverlessworkflow/diagram-editor"
 
 [build]
   command = """
     set -e
-    PREVIEW_PACKAGE_NAME='@serverlessworkflow/diagram-editor'
-    pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME" || { echo "Skip build: No changes detected"; exit 0; }
-    echo "Building ${PREVIEW_PACKAGE_NAME}##################################################"
     pnpm -F "${PREVIEW_PACKAGE_NAME}..." build:dev
     pnpm -F "$PREVIEW_PACKAGE_NAME" build:storybook
   """
   publish = "packages/serverless-workflow-diagram-editor/dist-storybook"
+  ignore = """
+    set -e
+    pnpm i -g "pnpm@$PNPM_VERSION"
+    ! pnpm -F '...[origin/issue-30-feat-Add-GitHub-Action-to-publish-Storybook-preview-for-every-PR-via-netlify]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
+  """

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,5 +29,5 @@
   ignore = """
     set -e
     npm i -g "pnpm@$PNPM_VERSION"
-    ! pnpm -F '...[origin/issue-30-feat-Add-GitHub-Action-to-publish-Storybook-preview-for-every-PR-via-netlify]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
+    ! pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
   """


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/30

### Description

Add a GitHub Actions workflow that publishes a live Storybook preview for every pull request using Netlify.

The goal is that each PR gets a preview URL where reviewers and contributors can open and interact with the Storybook build for that branch, without needing to run the project locally. 

### Motivation

Reviewing UI and UX changes is much easier when a live preview is available directly from the PR.

This would help us:

- let reviewers test Storybook examples from any PR
- make component and editor UX changes easier to validate
- reduce the need for local checkout just to review visual changes
- give contributors a shared preview environment during implementation

### Proposed Implementation

_No response_

### Definition of Done

- [x] Implementation: Fully implemented according to the Serverless Workflow spec.
- [ ] Unit Tests: Comprehensive unit tests are included and passing.
- [ ] Integration Tests: Verified within the monorepo and target environments (Web/VS Code).
- [ ] Documentation: Updated README.md, ADRs, or official docs.
- [ ] Performance: No significant regression in editor responsiveness.
- [ ] Accessibility: UI changes comply with accessibility standards.


## Preview PR from my fork:
I created 2 test PR against my fork to show what is the final result of this configuration:
- This is a test PR without any changes in the editor package to preview, and the configuration skips the preview:
https://github.com/fantonangeli/serverlessworkflow-editor/pull/3 
- This is a test PR with a small change in the editor package to preview, and the configuration show the preview link in PR comment:
https://github.com/fantonangeli/serverlessworkflow-editor/pull/4