### PR TITLE
fix #56 - feat: Convert tsc configuration to vite build

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "clean": "rimraf ./dist",
-    "build:dev": "pnpm clean && tsc -p tsconfig.json",
+    "build:dev": "pnpm clean && tsc -p tsconfig.json && vite build",
     "build:prod": "pnpm run build:dev && pnpm test",
     "test": "vitest run --passWithNoTests"
   },
@@ -28,6 +28,7 @@
     "@types/react-dom": "catalog:",
     "rimraf": "catalog:",
     "typescript": "catalog:",
+    "vite": "catalog:",
     "vite-tsconfig-paths": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -4,8 +4,9 @@
     "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-
+    "sourceMap": false,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "rootDirs": ["./src", "./tests"],
     "outDir": "./dist"
   },

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   resolve: {

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       formats: ["es"],
     },
     rollupOptions: {
-      external: ["react", "react-dom"],
+      external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     },
   },
   plugins: [

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     emptyOutDir: false,
     sourcemap: true,
@@ -30,10 +32,4 @@ export default defineConfig({
       external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     },
   },
-  plugins: [
-    tsconfigPaths({
-      // Provide an array of paths to the tsconfig files you want to use
-      projects: ["./tsconfig.json"],
-    }),
-  ],
 });

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       entry: "src/index.ts",
-      fileName: "index",
+      fileName: (format) => (format === "es" ? "index.js" : `index.${format}.js`),
       formats: ["es"],
     },
     rollupOptions: {

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/packages/i18n/vite.config.ts
+++ b/packages/i18n/vite.config.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    lib: {
+      entry: "src/index.ts",
+      fileName: "index",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: ["react", "react-dom"],
+    },
+  },
+  plugins: [
+    tsconfigPaths({
+      // Provide an array of paths to the tsconfig files you want to use
+      projects: ["./tsconfig.json"],
+    }),
+  ],
+});

--- a/packages/serverless-workflow-diagram-editor/package.json
+++ b/packages/serverless-workflow-diagram-editor/package.json
@@ -31,8 +31,8 @@
     "format:check": "oxfmt --config .oxfmtrc.json --check",
     "clean": "rimraf ./dist",
     "clean:storybook": "rimraf ./dist-storybook",
-    "build:dev": "pnpm clean && tsc -p tsconfig.json",
-    "build:prod": "pnpm lint && pnpm clean && tsc -p tsconfig.json && pnpm test",
+    "build:dev": "pnpm clean && tsc -p tsconfig.json && vite build",
+    "build:prod": "pnpm lint && pnpm clean && tsc -p tsconfig.json && vite build && pnpm test",
     "test": "vitest run --passWithNoTests",
     "start": "storybook dev -p 6006 --no-open",
     "build:storybook": "pnpm clean:storybook && storybook build --output-dir ./dist-storybook"

--- a/packages/serverless-workflow-diagram-editor/tsconfig.json
+++ b/packages/serverless-workflow-diagram-editor/tsconfig.json
@@ -5,8 +5,9 @@
     "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-
+    "sourceMap": false,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "rootDirs": ["./src", "./tests"],
     "outDir": "./dist"
   },

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   resolve: {

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       formats: ["es"],
     },
     rollupOptions: {
-      external: ["react", "react-dom"],
+      external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     },
   },
   plugins: [

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
   build: {
     emptyOutDir: false,
     sourcemap: true,
@@ -30,10 +32,4 @@ export default defineConfig({
       external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
     },
   },
-  plugins: [
-    tsconfigPaths({
-      // Provide an array of paths to the tsconfig files you want to use
-      projects: ["./tsconfig.json"],
-    }),
-  ],
 });

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       entry: "src/index.ts",
-      fileName: "index",
+      fileName: (format) => (format === "es" ? "index.js" : `index.${format}.js`),
       formats: ["es"],
     },
     rollupOptions: {

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    lib: {
+      entry: "src/index.ts",
+      fileName: "index",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: ["react", "react-dom"],
+    },
+  },
+  plugins: [
+    tsconfigPaths({
+      // Provide an array of paths to the tsconfig files you want to use
+      projects: ["./tsconfig.json"],
+    }),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ catalogs:
       specifier: ^5.9.3
       version: 5.9.3
     vite:
-      specifier: ^6.0.0
+      specifier: ^6.4.1
       version: 6.4.1
     vite-tsconfig-paths:
       specifier: ^6.1.1
@@ -153,6 +153,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.1(@types/node@25.5.0)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: 'catalog:'
         version: 6.1.1(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(yaml@2.8.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,6 @@ packages:
   - packages/*
 catalog:
   "@chromatic-com/storybook": ^5.0.1
-  "js-yaml": ^4.1.1
   "@serverlessworkflow/sdk": ^1.0.1
   "@storybook/addon-a11y": ^10.2.19
   "@storybook/addon-docs": ^10.2.19
@@ -20,6 +19,7 @@ catalog:
   "@vitest/ui": ^4.1.0
   "@xyflow/react": ^12.10.1
   husky: ^9.1.7
+  "js-yaml": ^4.1.1
   jsdom: ^25.0.0
   lint-staged: ^16.4.0
   oxfmt: ^0.41.0
@@ -30,7 +30,7 @@ catalog:
   storybook: ^10.2.19
   syncpack: ^14.2.0
   typescript: ^5.9.3
-  vite: ^6.0.0
+  vite: ^6.4.1
   vite-tsconfig-paths: ^6.1.1
   vitest: ^4.1.0
 cleanupUnusedCatalogs: true


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/56

### Description

### Summary

We still have some `ŧsc` configuration in our `package.json` files which we should convert to `vite build` command using: https://vite.dev/guide/#command-line-interface

Current configuration:
https://github.com/serverlessworkflow/editor/blob/33bdc2db6cd11fca6e295a51d1664d3ab0a8e812/packages/serverless-workflow-diagram-editor/package.json#L35

### Goals

- Build our source using vite
- The CI should fail if the build is not successful

### Non-Goals
- Replace entirely tsc build in the repository
- Disable or break linting configuration
- Disable or break tsc type checking


### Motivation

Get the bundling advantages from vite, and improved performance

### Proposed Implementation

Take inspiration from "vite-react-typescript-starter": https://github.com/vitejs/vite/blob/main/packages/create-vite/template-react-ts/package.json

### Definition of Done

- [ ] Implementation: Fully implemented according to the Serverless Workflow spec.
- [ ] Unit Tests: Comprehensive unit tests are included and passing.
- [ ] Integration Tests: Verified within the monorepo and target environments (Web/VS Code).
- [ ] Documentation: Updated README.md, ADRs, or official docs.
- [ ] Performance: No significant regression in editor responsiveness.
- [ ] Accessibility: UI changes comply with accessibility standards.


## Preview with error:
```
fantonan:serverless-workflow-diagram-editor$ pnpm build:dev

> @serverlessworkflow/diagram-editor@0.0.0 build:dev /home/fantonan/NotBackedUp/repos/serverlessworkflow-editor/packages/serverless-workflow-diagram-editor
> pnpm clean && tsc -p tsconfig.json && vite build


> @serverlessworkflow/diagram-editor@0.0.0 clean /home/fantonan/NotBackedUp/repos/serverlessworkflow-editor/packages/serverless-workflow-diagram-editor
> rimraf ./dist

src/diagram-editor/DiagramEditor.tsx:28:7 - error TS2322: Type 'number' is not assignable to type 'string'.

28 const testTypeError: string = 123;
```