### PR TITLE
fix #65 - feat: create a package.json validation CI

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -56,6 +56,11 @@ jobs:
           version: 10.31.0
           cache: true
 
+      - name: Check package versions
+        shell: bash
+        run: |
+          pnpm -r exec node -e "process.exit(require('./package.json').version === '0.0.0' ? 0 : 1)"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci_check_license_headers.yaml
+++ b/.github/workflows/ci_check_license_headers.yaml
@@ -34,6 +34,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.31.0
+          cache: true
+
       - name: "Setup JDK 17"
         uses: actions/setup-java@v5
         with:
@@ -97,3 +108,8 @@ jobs:
           else
             echo "✅ Apache RAT check PASSED - All files have approved licenses."
           fi
+
+      - name: Check package.json licenses
+        shell: bash
+        run: |
+          pnpm -r exec node -e "process.exit(require('./package.json').license === 'Apache-2.0' ? 0 : 1)"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,17 @@
 {
   "name": "@serverlessworkflow/i18n",
   "version": "1.0.0",
+  "description": "Serverless workflow internationalization component",
+  "keywords": [],
+  "homepage": "https://github.com/serverlessworkflow/editor",
+  "bugs": {
+    "url": "https://github.com/serverlessworkflow/editor/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/serverlessworkflow/editor.git"
+  },
   "files": [
     "dist",
     "src"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessworkflow/i18n",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Serverless workflow internationalization component",
   "keywords": [],
   "homepage": "https://github.com/serverlessworkflow/editor",


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/65

### Description

Add a package.json validation CI to enforce that versions and license fields are the same across packages. 

### Motivation

Check that our package.json files have the right values, following our standard.

### Proposed Implementation

Using `pnpm exec`+`node`. `syncpack` has an [issue](https://github.com/JamieMason/syncpack/issues/325) checking local versions. `jq` works well but can be missed in Win

## Preview:
Expected CI failures:
- Build: https://github.com/serverlessworkflow/editor/actions/runs/24520171629/job/71675402749?pr=99
- License check: https://github.com/serverlessworkflow/editor/actions/runs/24520174443/job/71675412000?pr=99

Green CI, after package.json fix:
- License check: https://github.com/serverlessworkflow/editor/actions/runs/24520640378/job/71677086849?pr=99
- Build: https://github.com/serverlessworkflow/editor/actions/runs/24520640375/job/71677087124?pr=99