### PR TITLE
feat: Define node types and create React Flow node components #51

### DIFF
--- a/packages/serverless-workflow-diagram-editor/src/core/autoLayout.ts
+++ b/packages/serverless-workflow-diagram-editor/src/core/autoLayout.ts
@@ -16,11 +16,17 @@
 
 import { ExtendedGraph, Position, Size } from "./graph";
 
+// Defaults
+export const DEFAULT_NODE_SIZE = {
+  height: 50,
+  width: 90,
+};
+
 export function applyAutoLayout(graph: ExtendedGraph): ExtendedGraph {
   const graphClone = structuredClone(graph);
 
   // TODO: This is just a temporary implementation until the actual auto-layout engine is integrated
-  const nodeSize: Size = { height: 50, width: 70 };
+  const nodeSize: Size = DEFAULT_NODE_SIZE;
   let position: Position = { x: 0, y: 0 };
 
   // TODO: Containment is not supported for now.

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -35,3 +35,32 @@
         background-color: inherit;
     }
 }
+
+/* React flow Nodes */
+
+.node-label-container {
+    white-space: pre;
+    padding: 7px; 
+}
+
+.custom-node-container {
+    border-radius: 5px;
+    background: white;
+    border: 1px solid #000;
+    transition: border ease, box-shadow ease;
+    height: calc(100% - 2px); /* compensate for the border */
+    width: calc(100% - 2px); /* compensate for the border */
+}
+
+.custom-node-container:hover {
+    border: 1px solid #000;
+    box-shadow: 0 0 10px rgba(0, 65, 208, 0.3);
+    height: calc(100% - 2px); /* compensate for the border */
+    width: calc(100% - 2px); /* compensate for the border */
+}
+
+.custom-node-container.selected {
+    background: #aebbd5;
+    border: 1px solid #000;
+    box-shadow: 0 0 10px rgba(1, 79, 248, 0.3);
+}

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -16,9 +16,12 @@
 
 import * as React from "react";
 import * as RF from "@xyflow/react";
+import { GraphNodeType } from "@serverlessworkflow/sdk";
+import { NodeTypes } from "../nodes/Nodes";
+import { DEFAULT_NODE_SIZE } from "../../core";
+import { ColorMode } from "../../types/colorMode";
 import "@xyflow/react/dist/style.css";
 import "./Diagram.css";
-import { ColorMode } from "../../types/colorMode";
 
 const FIT_VIEW_OPTIONS: RF.FitViewOptions = {
   maxZoom: 1,
@@ -29,18 +32,117 @@ const FIT_VIEW_OPTIONS: RF.FitViewOptions = {
 // TODO: Nodes and Edges are hardcoded for now to generate a renderable basic workflow
 // It shall be replaced by the actual implementation based on graph structure
 const initialNodes: RF.Node[] = [
-  { id: "n1", position: { x: 100, y: 0 }, data: { label: "Node 1" } },
-  { id: "n2", position: { x: 100, y: 100 }, data: { label: "Node 2" } },
-  { id: "n3", position: { x: 0, y: 200 }, data: { label: "Node 3" } },
-  { id: "n4", position: { x: 200, y: 200 }, data: { label: "Node 4" } },
-  { id: "n5", position: { x: 100, y: 300 }, data: { label: "Node 5" } },
+  {
+    id: "n1",
+    type: GraphNodeType.Call,
+    position: { x: 100, y: 0 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 1" },
+  },
+  {
+    id: "n2",
+    type: GraphNodeType.Do,
+    position: { x: 100, y: 100 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 2" },
+  },
+  {
+    id: "n3",
+    type: GraphNodeType.Switch,
+    position: { x: 100, y: 200 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 3" },
+  },
+  {
+    id: "n4",
+    type: GraphNodeType.Emit,
+    position: { x: 0, y: 300 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 4" },
+  },
+  {
+    id: "n5",
+    type: GraphNodeType.For,
+    position: { x: 100, y: 300 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 5" },
+  },
+  {
+    id: "n6",
+    type: GraphNodeType.Fork,
+    position: { x: 200, y: 300 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 6" },
+  },
+  {
+    id: "n7",
+    type: GraphNodeType.Listen,
+    position: { x: 100, y: 400 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 7" },
+  },
+  {
+    id: "n8",
+    type: GraphNodeType.Raise,
+    position: { x: 100, y: 500 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 8" },
+  },
+  {
+    id: "n9",
+    type: GraphNodeType.Run,
+    position: { x: 100, y: 600 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 9" },
+  },
+  {
+    id: "n10",
+    type: GraphNodeType.Set,
+    position: { x: 100, y: 700 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 10" },
+  },
+  {
+    id: "n11",
+    type: GraphNodeType.Try,
+    position: { x: 100, y: 800 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 11" },
+  },
+  {
+    id: "n12",
+    type: GraphNodeType.Wait,
+    position: { x: 100, y: 900 },
+    height: DEFAULT_NODE_SIZE.height,
+    width: DEFAULT_NODE_SIZE.width,
+    data: { label: "Node 12" },
+  },
 ];
 const initialEdges: RF.Edge[] = [
   { id: "n1-n2", source: "n1", target: "n2" },
   { id: "n2-n3", source: "n2", target: "n3" },
-  { id: "n2-n4", source: "n2", target: "n4" },
+  { id: "n3-n4", source: "n3", target: "n4" },
   { id: "n3-n5", source: "n3", target: "n5" },
-  { id: "n4-n5", source: "n4", target: "n5" },
+  { id: "n3-n6", source: "n3", target: "n6" },
+  { id: "n4-n7", source: "n4", target: "n7" },
+  { id: "n5-n7", source: "n5", target: "n7" },
+  { id: "n6-n7", source: "n6", target: "n7" },
+  { id: "n7-n8", source: "n7", target: "n8" },
+  { id: "n8-n9", source: "n8", target: "n9" },
+  { id: "n9-n10", source: "n9", target: "n10" },
+  { id: "n10-n11", source: "n10", target: "n11" },
+  { id: "n11-n12", source: "n11", target: "n12" },
 ];
 
 /**
@@ -83,6 +185,7 @@ export const Diagram = ({ divRef, ref, colorMode = "system" }: DiagramProps) => 
   return (
     <div ref={divRef} className={`diagram-container colorMode-${colorMode}`} data-testid={"diagram-container"}>
       <RF.ReactFlow
+        nodeTypes={NodeTypes}
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}
@@ -96,6 +199,7 @@ export const Diagram = ({ divRef, ref, colorMode = "system" }: DiagramProps) => 
         selectionOnDrag={true}
         fitView
         colorMode={colorMode}
+        data-testid={"react-flow-canvas"}
       >
         {minimapVisible && <RF.MiniMap pannable zoomable position={"top-right"} />}
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphNodeType } from "@serverlessworkflow/sdk";
+import * as RF from "@xyflow/react";
+
+// Node types must match sdk GraphNodeType enum
+export const NodeTypes: RF.NodeTypes = {
+  [GraphNodeType.Call]: CallNode,
+  [GraphNodeType.Do]: DoNode,
+  [GraphNodeType.Emit]: EmitNode,
+  [GraphNodeType.For]: ForNode,
+  [GraphNodeType.Fork]: ForkNode,
+  [GraphNodeType.Listen]: ListenNode,
+  [GraphNodeType.Raise]: RaiseNode,
+  [GraphNodeType.Run]: RunNode,
+  [GraphNodeType.Set]: SetNode,
+  [GraphNodeType.Switch]: SwitchNode,
+  [GraphNodeType.Try]: TryNode,
+  [GraphNodeType.Wait]: WaitNode,
+};
+
+export type BaseNodeData = {
+  // TODO: It is a placeholder, add properties to be consumed internally by node components
+  label: string;
+};
+
+// TODO: These props are just a placeholder
+interface PlaceholderProps {
+  id: string;
+  data: BaseNodeData;
+  selected: boolean;
+  type: string;
+}
+
+// TODO: This content is just a placeholder
+function PlaceholderContent({ id, data, selected, type }: PlaceholderProps) {
+  return (
+    <div
+      className={`custom-node-container ${selected ? "selected" : ""}`}
+      data-testid={`${type}-node-${id}`}
+    >
+      <RF.Handle type="target" position={RF.Position.Top} />
+      <div className="node-label-container" data-testid={`${type}-label-${id}`}>
+        {`${type}\n${data.label}`}
+      </div>
+      <RF.Handle type="source" position={RF.Position.Bottom} />
+    </div>
+  );
+}
+
+/* call node */
+export type CallNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Call>;
+export function CallNode({ id, data, selected, type }: RF.NodeProps<CallNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* do node */
+export type DoNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Do>;
+export function DoNode({ id, data, selected, type }: RF.NodeProps<DoNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* emit node */
+export type EmitNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Emit>;
+export function EmitNode({ id, data, selected, type }: RF.NodeProps<EmitNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* for node */
+export type ForNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.For>;
+export function ForNode({ id, data, selected, type }: RF.NodeProps<ForNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* fork node */
+export type ForkNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Fork>;
+export function ForkNode({ id, data, selected, type }: RF.NodeProps<ForkNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* listen node */
+export type ListenNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Listen>;
+export function ListenNode({ id, data, selected, type }: RF.NodeProps<ListenNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* raise node */
+export type RaiseNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Raise>;
+export function RaiseNode({ id, data, selected, type }: RF.NodeProps<RaiseNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* run node */
+export type RunNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Run>;
+export function RunNode({ id, data, selected, type }: RF.NodeProps<RunNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* set node */
+export type SetNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Set>;
+export function SetNode({ id, data, selected, type }: RF.NodeProps<SetNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* switch node */
+export type SwitchNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Switch>;
+export function SwitchNode({ id, data, selected, type }: RF.NodeProps<SwitchNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* try node */
+export type TryNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Try>;
+export function TryNode({ id, data, selected, type }: RF.NodeProps<TryNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* wait node */
+export type WaitNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Wait>;
+export function WaitNode({ id, data, selected, type }: RF.NodeProps<WaitNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+}

--- a/packages/serverless-workflow-diagram-editor/tests-e2e/diagram-editor.spec.ts
+++ b/packages/serverless-workflow-diagram-editor/tests-e2e/diagram-editor.spec.ts
@@ -27,9 +27,9 @@ test("diagram editor renders correctly", async ({ page }) => {
 
   // Check total nodes
   const nodes = page.locator('[data-testid^="rf__node-"]');
-  await expect(nodes).toHaveCount(5);
+  await expect(nodes).toHaveCount(12);
 
   // Check total edge
   const edges = page.locator('[data-testid^="rf__edge-"]');
-  await expect(edges).toHaveCount(5);
+  await expect(edges).toHaveCount(13);
 });

--- a/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.test.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { DiagramEditor } from "../../src/diagram-editor";
-import { vi, test, expect, afterEach, describe, it } from "vitest";
+import { vi, expect, afterEach, describe, it } from "vitest";
 import { BASIC_VALID_WORKFLOW_YAML } from "../fixtures/workflows";
 
 describe("DiagramEditor Component", () => {

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -15,27 +15,21 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { Diagram } from "../../../src/react-flow/diagram/Diagram";
 import { vi, test, expect, afterEach, describe } from "vitest";
+import { Diagram } from "../../../src/react-flow/diagram/Diagram";
 
 describe("Diagram Component", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test("Renders react flow nodes", async () => {
+  test("render Diagram component and canvas", () => {
     render(<Diagram />);
 
-    const node1 = screen.getByText("Node 1");
-    const node2 = screen.getByText("Node 2");
-    const node3 = screen.getByText("Node 3");
-    const node4 = screen.getByText("Node 4");
-    const node5 = screen.getByText("Node 5");
+    const diagram = screen.getByTestId("diagram-container");
+    const canvas = screen.getByTestId("react-flow-canvas");
 
-    expect(node1).toBeInTheDocument();
-    expect(node2).toBeInTheDocument();
-    expect(node3).toBeInTheDocument();
-    expect(node4).toBeInTheDocument();
-    expect(node5).toBeInTheDocument();
+    expect(diagram).toBeInTheDocument();
+    expect(canvas).toBeInTheDocument();
   });
 });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/nodes/Nodes.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/nodes/Nodes.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { vi, it, expect, afterEach, describe } from "vitest";
+import * as RF from "@xyflow/react";
+import { GraphNodeType } from "@serverlessworkflow/sdk";
+import { NodeTypes } from "../../../src/react-flow/nodes/Nodes";
+import { DEFAULT_NODE_SIZE } from "../../../src/core";
+
+describe("React Flow custom node types", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("render react flow custom node types", () => {
+    const nodes: RF.Node[] = [
+      {
+        id: "n1",
+        type: GraphNodeType.Call,
+        position: { x: 100, y: 0 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 1" },
+      },
+      {
+        id: "n2",
+        type: GraphNodeType.Do,
+        position: { x: 100, y: 100 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 2" },
+      },
+      {
+        id: "n3",
+        type: GraphNodeType.Switch,
+        position: { x: 100, y: 200 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 3" },
+      },
+      {
+        id: "n4",
+        type: GraphNodeType.Emit,
+        position: { x: 0, y: 300 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 4" },
+      },
+      {
+        id: "n5",
+        type: GraphNodeType.For,
+        position: { x: 100, y: 300 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 5" },
+      },
+      {
+        id: "n6",
+        type: GraphNodeType.Fork,
+        position: { x: 200, y: 300 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 6" },
+      },
+      {
+        id: "n7",
+        type: GraphNodeType.Listen,
+        position: { x: 100, y: 400 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 7" },
+      },
+      {
+        id: "n8",
+        type: GraphNodeType.Raise,
+        position: { x: 100, y: 500 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 8" },
+      },
+      {
+        id: "n9",
+        type: GraphNodeType.Run,
+        position: { x: 100, y: 600 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 9" },
+      },
+      {
+        id: "n10",
+        type: GraphNodeType.Set,
+        position: { x: 100, y: 700 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 10" },
+      },
+      {
+        id: "n11",
+        type: GraphNodeType.Try,
+        position: { x: 100, y: 800 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 11" },
+      },
+      {
+        id: "n12",
+        type: GraphNodeType.Wait,
+        position: { x: 100, y: 900 },
+        height: DEFAULT_NODE_SIZE.height,
+        width: DEFAULT_NODE_SIZE.width,
+        data: { label: "Node 12" },
+      },
+    ];
+
+    const edges: RF.Edge[] = [
+      { id: "n1-n2", source: "n1", target: "n2" },
+      { id: "n2-n3", source: "n2", target: "n3" },
+      { id: "n3-n4", source: "n3", target: "n4" },
+      { id: "n3-n5", source: "n3", target: "n5" },
+      { id: "n3-n6", source: "n3", target: "n6" },
+      { id: "n4-n7", source: "n4", target: "n7" },
+      { id: "n5-n7", source: "n5", target: "n7" },
+      { id: "n6-n7", source: "n6", target: "n7" },
+      { id: "n7-n8", source: "n7", target: "n8" },
+      { id: "n8-n9", source: "n8", target: "n9" },
+      { id: "n9-n10", source: "n9", target: "n10" },
+      { id: "n10-n11", source: "n10", target: "n11" },
+      { id: "n11-n12", source: "n11", target: "n12" },
+    ];
+
+    render(
+      <div>
+        <RF.ReactFlow nodeTypes={NodeTypes} nodes={nodes} edges={edges} />
+      </div>,
+    );
+
+    const callNode = screen.getByTestId("call-node-n1");
+    const doNode = screen.getByTestId("do-node-n2");
+    const switchNode = screen.getByTestId("switch-node-n3");
+    const emitNode = screen.getByTestId("emit-node-n4");
+    const forNode = screen.getByTestId("for-node-n5");
+    const forkNode = screen.getByTestId("fork-node-n6");
+    const listenNode = screen.getByTestId("listen-node-n7");
+    const raiseNode = screen.getByTestId("raise-node-n8");
+    const runNode = screen.getByTestId("run-node-n9");
+    const setNode = screen.getByTestId("set-node-n10");
+    const tryNode = screen.getByTestId("try-node-n11");
+    const waitNode = screen.getByTestId("wait-node-n12");
+
+    expect(callNode).toBeInTheDocument();
+    expect(doNode).toBeInTheDocument();
+    expect(switchNode).toBeInTheDocument();
+    expect(emitNode).toBeInTheDocument();
+    expect(forNode).toBeInTheDocument();
+    expect(forkNode).toBeInTheDocument();
+    expect(listenNode).toBeInTheDocument();
+    expect(raiseNode).toBeInTheDocument();
+    expect(runNode).toBeInTheDocument();
+    expect(setNode).toBeInTheDocument();
+    expect(tryNode).toBeInTheDocument();
+    expect(waitNode).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes [#51](https://github.com/serverlessworkflow/editor/issues/51)

 ## Summary
This PR adds react flow node types and customizable node components for each task type also reenabling base behaviours such as borders, selection / deselection and  mouse hover.

## Changes
 * Added node types to initialize react flow with the supported node types.
 * Added customizable node react components for each one of the twelve tasks in the spec 1.0 .
 * Added default node size.
 * Added CSS styles to reestablish borders and default behaviors of the nodes (selection / deselection and hover).
 * Updated storybook to render and present the twelve supported node types.
 * Tests ensuring that all twelve node types are supported and renderable by react flow. 
 
<img width="1487" height="1299" alt="image" src="https://github.com/user-attachments/assets/a3fd1ed5-8473-463c-ab6f-08b88790351c" />