### PR TITLE
fix #121 - Configure Dependabot to open a single weekly dependency for each ecosystem update PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/121

### Description

Update the Dependabot configuration so dependency version updates are grouped into a single weekly pull request for each ecosystem, instead of opening multiple PRs during the week.

### Motivation

Reduce PR noise and make dependency maintenance easier to review and manage.

## Preview: 
I tried to run this dependabot CI on my fork using an outdated `main` branch and outdated GHA versions.
The 2 PRs created on my fork by this dependabot are:
- https://github.com/fantonangeli/serverlessworkflow-editor/pull/6
- https://github.com/fantonangeli/serverlessworkflow-editor/pull/7