### PR TITLE
fix #19 - Enable GitHub CodeQL scanning

### DIFF
--- a/.github/workflows/ci_check_license_headers.yaml
+++ b/.github/workflows/ci_check_license_headers.yaml
@@ -23,6 +23,9 @@ on:
     branches: ["**"]
     types: [opened, reopened, ready_for_review, synchronize]
 
+permissions:
+  contents: read
+
 env:
   APACHE_RAT_VERSION: 0.17
 

--- a/.github/workflows/ci_codeql.yml
+++ b/.github/workflows/ci_codeql.yml
@@ -48,6 +48,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          queries: security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/ci_codeql.yml
+++ b/.github/workflows/ci_codeql.yml
@@ -1,0 +1,53 @@
+#
+# Copyright 2021-Present The Serverless Workflow Specification Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "CI :: CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Monday at 12:00 UTC.
+    - cron: "0 12 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript", "actions"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/sync-issues-to-project.yml
+++ b/.github/workflows/sync-issues-to-project.yml
@@ -21,6 +21,9 @@ on:
     types: [opened, closed]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/19

### Summary

Configure GitHub’s CodeQL code scanning for this repository to analyze the JavaScript/TypeScript codebase, catch common security issues early, and surface findings in the repo Security → Code scanning alerts.

### Goals

- Enable CodeQL analysis for JS/TS to detect common vulnerabilities and insecure patterns.
- Run analysis automatically via GitHub Actions and publish results to the Security tab.
- Keep configuration lightweight and maintainable for an OSS repo.

### Non-Goals

- Custom CodeQL queries on day one.
- Scanning non-JS/TS languages unless required.
- Treating CodeQL as a replacement for unit tests/linting.

## Notes:
- I enabled the CodeQL scan for `TS/JS` files and also for GH Actions.
  The scan found 2 medium issues in 2 CIs and I fixed them in this PR:
  - .github/workflows/ci_check_license_headers.yaml
  - .github/workflows/sync-issues-to-project.yml (CC @dgutierr ) 

## Preview:
I created 2 PRs to test the result on my fork:
- Safe PR which is green: https://github.com/fantonangeli/serverlessworkflow-editor/pull/9
- Unsafe PR which is red with report: https://github.com/fantonangeli/serverlessworkflow-editor/pull/8