### PR TITLE
NO-ISSUE: Fix warning: A control must be associated with a text label.

### DIFF
--- a/packages/serverless-workflow-diagram-editor/stories/DiagramEditorDragNDrop.tsx
+++ b/packages/serverless-workflow-diagram-editor/stories/DiagramEditorDragNDrop.tsx
@@ -93,6 +93,7 @@ export const DiagramEditorDragNDrop = (props: Omit<DiagramEditorProps, "content"
         <div>
           or{" "}
           <label
+            id="file-upload-label"
             htmlFor="file-upload"
             className="dec:text-blue-600 dec:underline dec:cursor-pointer"
           >
@@ -106,6 +107,7 @@ export const DiagramEditorDragNDrop = (props: Omit<DiagramEditorProps, "content"
           accept=".yaml,.yml,.json"
           onChange={handleFileChange}
           data-testid="story-workflow-file-upload"
+          aria-labelledby="file-upload-label"
         />
       </div>
       {content && <Component {...props} content={content} />}

--- a/packages/serverless-workflow-diagram-editor/stories/DiagramEditorDragNDrop.tsx
+++ b/packages/serverless-workflow-diagram-editor/stories/DiagramEditorDragNDrop.tsx
@@ -93,7 +93,6 @@ export const DiagramEditorDragNDrop = (props: Omit<DiagramEditorProps, "content"
         <div>
           or{" "}
           <label
-            id="file-upload-label"
             htmlFor="file-upload"
             className="dec:text-blue-600 dec:underline dec:cursor-pointer"
           >
@@ -107,7 +106,7 @@ export const DiagramEditorDragNDrop = (props: Omit<DiagramEditorProps, "content"
           accept=".yaml,.yml,.json"
           onChange={handleFileChange}
           data-testid="story-workflow-file-upload"
-          aria-labelledby="file-upload-label"
+          aria-label="upload a file"
         />
       </div>
       {content && <Component {...props} content={content} />}


### PR DESCRIPTION
This fixes the warning:
```
> oxlint --config .oxlintrc.json src/ stories/ tests/


  ⚠ jsx-a11y(control-has-associated-label): A control must be associated with a text label.
     ╭─[stories/DiagramEditorDragNDrop.tsx:102:9]
 101 │             </div>
 102 │ ╭─▶         <input
 103 │ │             id="file-upload"
 104 │ │             className="dec:hidden"
 105 │ │             type="file"
 106 │ │             accept=".yaml,.yml,.json"
 107 │ │             onChange={handleFileChange}
 108 │ │             data-testid="story-workflow-file-upload"
 109 │ ╰─▶         />
 110 │           </div>
     ╰────
  help: Add a text label to the control element. This can be done by adding text content, an `aria-label` attribute, or an `aria-labelledby` attribute.
```
