### PR TITLE
fix #158 - bug: license header CI is failing randomly

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -17,6 +17,12 @@
 name: "Setup CI"
 description: "Setup Node.js and pnpm for CI workflows"
 
+inputs:
+  pnpm_cache:
+    description: "Enable pnpm cache. Disable if the workflow does not run pnpm install."
+    required: false
+    default: "true"
+
 runs:
   using: "composite"
   steps:
@@ -29,4 +35,4 @@ runs:
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:
         version: 10.31.0
-        cache: true
+        cache: ${{ inputs.pnpm_cache == 'true' }}

--- a/.github/workflows/ci_check_license_headers.yaml
+++ b/.github/workflows/ci_check_license_headers.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Setup CI
         uses: ./.github/actions/setup-ci
+        with:
+          pnpm_cache: "false"
 
       - name: "Setup JDK 17"
         uses: actions/setup-java@v5


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/158

### Describe the Bug

The CI License check is failing randomly on new PRs with:
```
Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```
CI run: https://github.com/serverlessworkflow/editor/actions/runs/26499406741/job/78035638385?pr=151
PR with the failure: https://github.com/serverlessworkflow/editor/pull/151

### Steps to reproduce

1. Create a PR
2. Check the result of `CI :: License headers / check (pull_request)`

### Expected Behavior

The CI does the checks without issues

### Preview:
See the checks of this PR:
https://github.com/serverlessworkflow/editor/actions/runs/26564754355/job/78256455815