### PR TITLE
Make workflow read only by disabling drag-and-drop and edge handles

### DIFF
--- a/.changeset/read-only-mode.md
+++ b/.changeset/read-only-mode.md
@@ -2,4 +2,4 @@
 "@serverlessworkflow/diagram-editor": minor
 ---
 
-Enable read only mode locking nodes and edges on the canvas.
+Enable read-only mode locking nodes and edges on the canvas.

--- a/.changeset/read-only-mode.md
+++ b/.changeset/read-only-mode.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": minor
+---
+
+Enable read only mode locking nodes and edges on the canvas.

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -60,6 +60,10 @@
   /* hide handles in read-only mode */
   .dec-root .read-only .react-flow__handle {
     visibility: hidden !important;
+    width: 0 !important;
+    height: 0 !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
   }
 }
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -56,6 +56,11 @@
   .dec-root .react-flow__pane:active {
     cursor: grabbing !important;
   }
+
+  /* hide handles in read-only mode */
+  .dec-root .read-only .react-flow__handle {
+    visibility: hidden !important;
+  }
 }
 
 /* custom nodes */

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -128,9 +128,7 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   return (
     <div
       ref={divRef}
-      className={["dec:h-full", "dec:relative", isReadOnly && "read-only"]
-        .filter(Boolean)
-        .join(" ")}
+      className={isReadOnly ? "dec:h-full dec:relative read-only" : "dec:h-full dec:relative"}
       data-testid={"diagram-container"}
     >
       <RF.ReactFlow

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -47,7 +47,7 @@ export type DiagramProps = {
 
 export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   const reactFlowInstance: RF.ReactFlowInstance = RF.useReactFlow();
-  const { model, nodes, edges, setNodes, setEdges } = useDiagramEditorContext();
+  const { model, nodes, edges, isReadOnly, setNodes, setEdges } = useDiagramEditorContext();
 
   const [minimapVisible, setMinimapVisible] = React.useState(false);
 
@@ -126,7 +126,11 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   }, [model, reactFlowInstance, setNodes, setEdges]);
 
   return (
-    <div ref={divRef} className="dec:h-full dec:relative" data-testid={"diagram-container"}>
+    <div
+      ref={divRef}
+      className={`dec:h-full dec:relative ${isReadOnly ? "read-only" : ""}`}
+      data-testid={"diagram-container"}
+    >
       <RF.ReactFlow
         nodeTypes={ReactFlowNodeTypes}
         nodes={nodes}
@@ -151,6 +155,8 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
           },
         }}
         data-testid={"react-flow-canvas"}
+        nodesDraggable={!isReadOnly}
+        nodesConnectable={!isReadOnly}
       >
         {minimapVisible && <RF.MiniMap pannable zoomable position={"top-right"} />}
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -128,7 +128,9 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   return (
     <div
       ref={divRef}
-      className={`dec:h-full dec:relative ${isReadOnly ? "read-only" : ""}`}
+      className={["dec:h-full", "dec:relative", isReadOnly && "read-only"]
+        .filter(Boolean)
+        .join(" ")}
       data-testid={"diagram-container"}
     >
       <RF.ReactFlow

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -21,8 +21,19 @@ import { DiagramEditorContextProvider } from "../../../src/store/DiagramEditorCo
 import { SidebarProvider } from "../../../src/components/ui/sidebar";
 import { I18nProvider } from "@serverlessworkflow/i18n";
 import { en } from "../../../src/i18n/locales/en";
-import { ReactFlowProvider } from "@xyflow/react";
+import { ReactFlowProvider, ReactFlow } from "@xyflow/react";
 import * as autoLayoutModule from "../../../src/react-flow/diagram/autoLayout";
+
+// Mock ReactFlow to capture props
+vi.mock("@xyflow/react", async () => {
+  const actual = await vi.importActual("@xyflow/react");
+  return {
+    ...actual,
+    ReactFlow: vi.fn((props) => {
+      return <div data-testid="react-flow-canvas" {...props} />;
+    }),
+  };
+});
 
 /**
  * Helper function to render the Diagram component with all required providers
@@ -62,6 +73,9 @@ describe("Diagram Component", () => {
       nodes: [],
       edges: [],
     });
+
+    // Clear mock calls before each test
+    vi.mocked(ReactFlow).mockClear();
   });
 
   afterEach(() => {
@@ -122,11 +136,16 @@ describe("Diagram Component", () => {
     const canvas = screen.getByTestId("react-flow-canvas");
     expect(canvas).toBeInTheDocument();
 
-    // Note: The actual CSS visibility of handles cannot be tested in JSDOM as it doesn't apply stylesheets.
-    // The read-only behavior is enforced through:
-    // 1. CSS class "read-only" which hides .react-flow__handle elements
-    // 2. ReactFlow props nodesDraggable={false} and nodesConnectable={false}
-    // For full verification of handle visibility, use e2e tests where CSS is applied.
+    // Wait for ReactFlow to be called
+    await waitFor(() => {
+      expect(ReactFlow).toHaveBeenCalled();
+    });
+
+    // Verify that ReactFlow was called with nodesDraggable={false} and nodesConnectable={false}
+    const mockReactFlow = vi.mocked(ReactFlow);
+    const reactFlowProps = mockReactFlow.mock.calls[mockReactFlow.mock.calls.length - 1][0];
+    expect(reactFlowProps.nodesDraggable).toBe(false);
+    expect(reactFlowProps.nodesConnectable).toBe(false);
 
     await waitFor(() => {
       expect(applyAutoLayoutSpy).toHaveBeenCalled();
@@ -145,9 +164,16 @@ describe("Diagram Component", () => {
     const canvas = screen.getByTestId("react-flow-canvas");
     expect(canvas).toBeInTheDocument();
 
-    // Note: When read-only class is not present, handles are visible via CSS
-    // and ReactFlow props nodesDraggable={true} and nodesConnectable={true} enable interaction.
-    // For full verification of handle visibility and interaction, use e2e tests.
+    // Wait for ReactFlow to be called
+    await waitFor(() => {
+      expect(ReactFlow).toHaveBeenCalled();
+    });
+
+    // Verify that ReactFlow was called with nodesDraggable={true} and nodesConnectable={true}
+    const mockReactFlow = vi.mocked(ReactFlow);
+    const reactFlowProps = mockReactFlow.mock.calls[mockReactFlow.mock.calls.length - 1][0];
+    expect(reactFlowProps.nodesDraggable).toBe(true);
+    expect(reactFlowProps.nodesConnectable).toBe(true);
 
     await waitFor(() => {
       expect(applyAutoLayoutSpy).toHaveBeenCalled();

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -24,6 +24,35 @@ import { en } from "../../../src/i18n/locales/en";
 import { ReactFlowProvider } from "@xyflow/react";
 import * as autoLayoutModule from "../../../src/react-flow/diagram/autoLayout";
 
+/**
+ * Helper function to render the Diagram component with all required providers
+ * @param options - Configuration options for the diagram
+ * @param options.isReadOnly - Whether the diagram should be in read-only mode
+ * @param options.content - The workflow content to render
+ * @param options.locale - The locale to use for i18n
+ */
+function renderDiagram({
+  isReadOnly = true,
+  content = "",
+  locale = "en",
+}: {
+  isReadOnly?: boolean;
+  content?: string;
+  locale?: string;
+} = {}) {
+  return render(
+    <ReactFlowProvider>
+      <DiagramEditorContextProvider content={content} isReadOnly={isReadOnly} locale={locale}>
+        <I18nProvider locale="en" dictionaries={{ en }}>
+          <SidebarProvider>
+            <Diagram />
+          </SidebarProvider>
+        </I18nProvider>
+      </DiagramEditorContextProvider>
+    </ReactFlowProvider>,
+  );
+}
+
 describe("Diagram Component", () => {
   let applyAutoLayoutSpy: ReturnType<typeof vi.spyOn>;
 
@@ -40,17 +69,7 @@ describe("Diagram Component", () => {
   });
 
   it("render Diagram component and canvas", async () => {
-    render(
-      <ReactFlowProvider>
-        <DiagramEditorContextProvider content={""} isReadOnly={true} locale={"en"}>
-          <I18nProvider locale="en" dictionaries={{ en }}>
-            <SidebarProvider>
-              <Diagram />
-            </SidebarProvider>
-          </I18nProvider>
-        </DiagramEditorContextProvider>
-      </ReactFlowProvider>,
-    );
+    renderDiagram({ isReadOnly: true });
 
     const diagram = screen.getByTestId("diagram-container");
     const canvas = screen.getByTestId("react-flow-canvas");
@@ -65,17 +84,7 @@ describe("Diagram Component", () => {
   });
 
   it("should apply read-only class when isReadOnly is true", async () => {
-    render(
-      <ReactFlowProvider>
-        <DiagramEditorContextProvider content={""} isReadOnly={true} locale={"en"}>
-          <I18nProvider locale="en" dictionaries={{ en }}>
-            <SidebarProvider>
-              <Diagram />
-            </SidebarProvider>
-          </I18nProvider>
-        </DiagramEditorContextProvider>
-      </ReactFlowProvider>,
-    );
+    renderDiagram({ isReadOnly: true });
 
     const diagram = screen.getByTestId("diagram-container");
 
@@ -88,17 +97,7 @@ describe("Diagram Component", () => {
   });
 
   it("should not apply read-only class when isReadOnly is false", async () => {
-    render(
-      <ReactFlowProvider>
-        <DiagramEditorContextProvider content={""} isReadOnly={false} locale={"en"}>
-          <I18nProvider locale="en" dictionaries={{ en }}>
-            <SidebarProvider>
-              <Diagram />
-            </SidebarProvider>
-          </I18nProvider>
-        </DiagramEditorContextProvider>
-      </ReactFlowProvider>,
-    );
+    renderDiagram({ isReadOnly: false });
 
     const diagram = screen.getByTestId("diagram-container");
 
@@ -110,50 +109,45 @@ describe("Diagram Component", () => {
     });
   });
 
-  it("should hide edge handles when isReadOnly is true", async () => {
-    const { container } = render(
-      <ReactFlowProvider>
-        <DiagramEditorContextProvider content={""} isReadOnly={true} locale={"en"}>
-          <I18nProvider locale="en" dictionaries={{ en }}>
-            <SidebarProvider>
-              <Diagram />
-            </SidebarProvider>
-          </I18nProvider>
-        </DiagramEditorContextProvider>
-      </ReactFlowProvider>,
-    );
+  it("should disable node interaction when isReadOnly is true", async () => {
+    renderDiagram({ isReadOnly: true });
 
     const diagram = screen.getByTestId("diagram-container");
 
-    // Verify that the read-only class is applied (which hides handles via CSS)
+    // Verify that the read-only class is applied
+    // This class applies CSS rule: .read-only .react-flow__handle { visibility: hidden !important; }
     expect(diagram).toHaveClass("read-only");
 
-    // Verify that the CSS rule for hiding handles exists
-    const styles = window.getComputedStyle(container);
-    expect(styles).toBeDefined();
+    // Verify ReactFlow canvas is rendered
+    const canvas = screen.getByTestId("react-flow-canvas");
+    expect(canvas).toBeInTheDocument();
+
+    // Note: The actual CSS visibility of handles cannot be tested in JSDOM as it doesn't apply stylesheets.
+    // The read-only behavior is enforced through:
+    // 1. CSS class "read-only" which hides .react-flow__handle elements
+    // 2. ReactFlow props nodesDraggable={false} and nodesConnectable={false}
+    // For full verification of handle visibility, use e2e tests where CSS is applied.
 
     await waitFor(() => {
       expect(applyAutoLayoutSpy).toHaveBeenCalled();
     });
   });
 
-  it("should show edge handles when isReadOnly is false", async () => {
-    render(
-      <ReactFlowProvider>
-        <DiagramEditorContextProvider content={""} isReadOnly={false} locale={"en"}>
-          <I18nProvider locale="en" dictionaries={{ en }}>
-            <SidebarProvider>
-              <Diagram />
-            </SidebarProvider>
-          </I18nProvider>
-        </DiagramEditorContextProvider>
-      </ReactFlowProvider>,
-    );
+  it("should enable node interaction when isReadOnly is false", async () => {
+    renderDiagram({ isReadOnly: false });
 
     const diagram = screen.getByTestId("diagram-container");
 
     // Verify that the read-only class is not applied
     expect(diagram).not.toHaveClass("read-only");
+
+    // Verify ReactFlow canvas is rendered
+    const canvas = screen.getByTestId("react-flow-canvas");
+    expect(canvas).toBeInTheDocument();
+
+    // Note: When read-only class is not present, handles are visible via CSS
+    // and ReactFlow props nodesDraggable={true} and nodesConnectable={true} enable interaction.
+    // For full verification of handle visibility and interaction, use e2e tests.
 
     await waitFor(() => {
       expect(applyAutoLayoutSpy).toHaveBeenCalled();

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -63,4 +63,100 @@ describe("Diagram Component", () => {
       expect(applyAutoLayoutSpy).toHaveBeenCalled();
     });
   });
+
+  it("should apply read-only class when isReadOnly is true", async () => {
+    render(
+      <ReactFlowProvider>
+        <DiagramEditorContextProvider content={""} isReadOnly={true} locale={"en"}>
+          <I18nProvider locale="en" dictionaries={{ en }}>
+            <SidebarProvider>
+              <Diagram />
+            </SidebarProvider>
+          </I18nProvider>
+        </DiagramEditorContextProvider>
+      </ReactFlowProvider>,
+    );
+
+    const diagram = screen.getByTestId("diagram-container");
+
+    // Verify that the read-only class is applied
+    expect(diagram).toHaveClass("read-only");
+
+    await waitFor(() => {
+      expect(applyAutoLayoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  it("should not apply read-only class when isReadOnly is false", async () => {
+    render(
+      <ReactFlowProvider>
+        <DiagramEditorContextProvider content={""} isReadOnly={false} locale={"en"}>
+          <I18nProvider locale="en" dictionaries={{ en }}>
+            <SidebarProvider>
+              <Diagram />
+            </SidebarProvider>
+          </I18nProvider>
+        </DiagramEditorContextProvider>
+      </ReactFlowProvider>,
+    );
+
+    const diagram = screen.getByTestId("diagram-container");
+
+    // Verify that the read-only class is not applied
+    expect(diagram).not.toHaveClass("read-only");
+
+    await waitFor(() => {
+      expect(applyAutoLayoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  it("should hide edge handles when isReadOnly is true", async () => {
+    const { container } = render(
+      <ReactFlowProvider>
+        <DiagramEditorContextProvider content={""} isReadOnly={true} locale={"en"}>
+          <I18nProvider locale="en" dictionaries={{ en }}>
+            <SidebarProvider>
+              <Diagram />
+            </SidebarProvider>
+          </I18nProvider>
+        </DiagramEditorContextProvider>
+      </ReactFlowProvider>,
+    );
+
+    const diagram = screen.getByTestId("diagram-container");
+
+    // Verify that the read-only class is applied (which hides handles via CSS)
+    expect(diagram).toHaveClass("read-only");
+
+    // Verify that the CSS rule for hiding handles exists
+    const styles = window.getComputedStyle(container);
+    expect(styles).toBeDefined();
+
+    await waitFor(() => {
+      expect(applyAutoLayoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  it("should show edge handles when isReadOnly is false", async () => {
+    render(
+      <ReactFlowProvider>
+        <DiagramEditorContextProvider content={""} isReadOnly={false} locale={"en"}>
+          <I18nProvider locale="en" dictionaries={{ en }}>
+            <SidebarProvider>
+              <Diagram />
+            </SidebarProvider>
+          </I18nProvider>
+        </DiagramEditorContextProvider>
+      </ReactFlowProvider>,
+    );
+
+    const diagram = screen.getByTestId("diagram-container");
+
+    // Verify that the read-only class is not applied
+    expect(diagram).not.toHaveClass("read-only");
+
+    await waitFor(() => {
+      expect(applyAutoLayoutSpy).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -30,7 +30,7 @@ vi.mock("@xyflow/react", async () => {
   return {
     ...actual,
     ReactFlow: vi.fn((props) => {
-      return <div data-testid="react-flow-canvas" {...props} />;
+      return <div data-testid="react-flow-canvas" />;
     }),
   };
 });
@@ -143,7 +143,9 @@ describe("Diagram Component", () => {
 
     // Verify that ReactFlow was called with nodesDraggable={false} and nodesConnectable={false}
     const mockReactFlow = vi.mocked(ReactFlow);
-    const reactFlowProps = mockReactFlow.mock.calls[mockReactFlow.mock.calls.length - 1][0];
+    const lastCall = mockReactFlow.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const reactFlowProps = lastCall![0];
     expect(reactFlowProps.nodesDraggable).toBe(false);
     expect(reactFlowProps.nodesConnectable).toBe(false);
 


### PR DESCRIPTION
Closes [#163](https://github.com/serverlessworkflow/editor/issues/163)

 ## Summary
This PR enables the read only mode by locking the workflow positioning in the canvas, however, it is still possible to select the nodes and edges and interact with the nodes.

## Changes
 * Use the readOnly prop to enable / disable node dragging. 
 * Use the readOnly prop to enable /disable node connection.
 * Use the readOnly prop to enable /disable node handles (connection dots on the top and bottom of the nodes).
 * Added CSS to hide node handles following react flow documentation.
 * Added tests covering the read only activation / deactivation. 

