### PR TITLE
fix #187: Dynamic require error from bundled use-sync-external-store shim

### DIFF
--- a/.changeset/fix-cjs-use-sync-external-store-bundle.md
+++ b/.changeset/fix-cjs-use-sync-external-store-bundle.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": minor
+---
+
+Fix ESM compatibility by keeping use-sync-external-store external in the build and declaring it as a runtime dependency.

--- a/packages/serverless-workflow-diagram-editor/package.json
+++ b/packages/serverless-workflow-diagram-editor/package.json
@@ -48,7 +48,8 @@
     "clsx": "catalog:",
     "elkjs": "catalog:",
     "js-yaml": "catalog:",
-    "radix-ui": "catalog:"
+    "radix-ui": "catalog:",
+    "use-sync-external-store": "catalog:"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "catalog:",

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -31,7 +31,14 @@ export default defineConfig({
       formats: ["es"],
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "react/jsx-dev-runtime",
+
+        /^use-sync-external-store($|\/)/, // Keep this external to avoid bundling the CJS shim into dist/index.js.
+      ],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
+    use-sync-external-store:
+      specifier: ^1.6.0
+      version: 1.6.0
     vite:
       specifier: ^8.0.16
       version: 8.0.16
@@ -227,6 +230,9 @@ importers:
       radix-ui:
         specifier: 'catalog:'
         version: 1.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      use-sync-external-store:
+        specifier: 'catalog:'
+        version: 1.6.0(react@19.2.7)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,7 @@ catalog:
   syncpack: ^15.2.0
   tailwindcss: ^4.3.0
   typescript: ^6.0.3
+  use-sync-external-store: ^1.6.0
   vite: ^8.0.16
   vitest: ^4.1.8
 cleanupUnusedCatalogs: true


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/187

### Describe the Bug

The diagram-editor package currently bundles the `use-sync-external-store`  as CJS. In some ESM/browser consumers, this can result in a CJS runtime call to `require("react")`, which fails in browser-only environments with:
```
Dynamic require of "react" is not supported
```
This issue prevents the entire package to be loaded by the browser.
This is related to the use-sync-external-store ESM compatibility issue discussed in [react/react#24590](https://github.com/react/react/issues/24590).

### How to test

1. Build the `@serverlessworkflow/diagram-editor` package 
2. Inspect the generated `dist/index.js`.
3. Observe the cjs path from the dist:
```
$ grep -n 'use-sync-external-store' packages/serverless-workflow-diagram-editor/dist/index.js 
``` 
No CJS is found
5. Load the Diagram Editor in the browser.
6. The Diagram Editor is not loaded

