### PR TITLE
feat: Highlight edge path on selection

### DIFF
--- a/.changeset/edge-path-highlight.md
+++ b/.changeset/edge-path-highlight.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": minor
+---
+
+Add edge path highlighting on selection.

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -408,7 +408,8 @@
 /* React flow SVG components do not work with classes defined into layers */
 .dec-root .edge-line {
   @apply dec:stroke-[#aea6a6]
-        dec:stroke-2;
+        dec:stroke-2
+        dec:transition-[filter];
 }
 
 .dec-root .edge-line.error {
@@ -418,6 +419,33 @@
 
 .dec-root .edge-line.condition {
   @apply dec:stroke-blue-500;
+}
+
+/* Override React Flow's default selected edge styling to preserve original colors */
+.dec-root .react-flow__edge.selected .edge-line {
+  stroke: #aea6a6 !important;
+}
+
+.dec-root .react-flow__edge.selected .edge-line.error {
+  stroke: var(--dec-error-accent) !important;
+}
+
+.dec-root .react-flow__edge.selected .edge-line.condition {
+  @apply dec:stroke-blue-500;
+  stroke: rgb(59 130 246) !important;
+}
+
+/* Selected edge shadow effect - lighter for light mode */
+.dec-root .edge-line.selected {
+  filter: drop-shadow(0 0 2px rgba(59, 130, 246, 0.8))
+          drop-shadow(0 0 6px rgba(59, 130, 246, 0.4))
+          drop-shadow(0 0 12px rgba(59, 130, 246, 0.2));
+}
+
+.dec-root.dark .edge-line.selected {
+  filter: drop-shadow(0 0 3px rgb(59 130 246))
+          drop-shadow(0 0 8px rgb(59 130 246))
+          drop-shadow(0 0 16px rgba(59, 130, 246, 0.8));
 }
 
 /* custom edge labels */

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -431,7 +431,6 @@
 }
 
 .dec-root .react-flow__edge.selected .edge-line.condition {
-  @apply dec:stroke-blue-500;
   stroke: rgb(59 130 246) !important;
 }
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -423,7 +423,7 @@
 
 /* Override React Flow's default selected edge styling to preserve original colors */
 .dec-root .react-flow__edge.selected .edge-line {
-  stroke: #aea6a6 !important;
+  stroke: var(--dec-edge-selected) !important;
 }
 
 .dec-root .react-flow__edge.selected .edge-line.error {
@@ -431,7 +431,7 @@
 }
 
 .dec-root .react-flow__edge.selected .edge-line.condition {
-  stroke: rgb(59 130 246) !important;
+  stroke: var(--dec-edge-selected-condition) !important;
 }
 
 /* Selected edge shadow effect - lighter for light mode */

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -66,10 +66,22 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
     (changes) => setNodes((nodesSnapshot) => RF.applyNodeChanges(changes, nodesSnapshot)),
     [setNodes],
   );
+
   const onEdgesChange = React.useCallback<RF.OnEdgesChange>(
-    (changes) => setEdges((edgesSnapshot) => RF.applyEdgeChanges(changes, edgesSnapshot)),
+    (changes) => {
+      setEdges((edgesSnapshot) => {
+        const updatedEdges = RF.applyEdgeChanges(changes, edgesSnapshot);
+
+        // Update zIndex for selected edges to bring them to front
+        return updatedEdges.map((edge) => ({
+          ...edge,
+          zIndex: edge.selected ? 1000 : 0,
+        }));
+      });
+    },
     [setEdges],
   );
+
   const onSelectionChange = React.useCallback<RF.OnSelectionChangeFunc>(
     ({ nodes: selectedNodes }) => setSelectedNodeId(selectedNodes[0]?.id ?? null),
     [setSelectedNodeId],

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/edges/Edges.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/edges/Edges.tsx
@@ -173,9 +173,7 @@ function CustomBaseEdge({
         targetPosition,
       })[0];
 
-  const edgeClassName = selected
-    ? `${className ?? "edge-line"} selected`
-    : (className ?? "edge-line");
+  const edgeClassName = `${className ?? "edge-line"}${selected ? " selected" : ""}`;
 
   return (
     <RF.BaseEdge id={id} path={edgePath} markerEnd={markerEnd ?? ""} className={edgeClassName} />

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/edges/Edges.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/edges/Edges.tsx
@@ -160,6 +160,7 @@ function CustomBaseEdge({
   data,
   markerEnd,
   className,
+  selected,
 }: RF.EdgeProps & { data?: BaseEdgeData; className?: string }) {
   const edgePath = data?.wayPoints
     ? createPathFromWayPoints(sourceX, sourceY, targetX, targetY, data.wayPoints)
@@ -172,13 +173,12 @@ function CustomBaseEdge({
         targetPosition,
       })[0];
 
+  const edgeClassName = selected
+    ? `${className ?? "edge-line"} selected`
+    : (className ?? "edge-line");
+
   return (
-    <RF.BaseEdge
-      id={id}
-      path={edgePath}
-      markerEnd={markerEnd ?? ""}
-      className={className ?? "edge-line"}
-    />
+    <RF.BaseEdge id={id} path={edgePath} markerEnd={markerEnd ?? ""} className={edgeClassName} />
   );
 }
 

--- a/packages/serverless-workflow-diagram-editor/src/styles.css
+++ b/packages/serverless-workflow-diagram-editor/src/styles.css
@@ -47,11 +47,15 @@
 
     --dec-error-accent: #ef4444;
     --dec-error-glow: rgba(239, 68, 68, 0.35);
+    --dec-edge-selected: #aea6a6;
+    --dec-edge-selected-condition: rgb(59 130 246);
   }
 
   .dec-root.dark{
         --dec-error-accent: #f87171;
     --dec-error-glow: rgba(248, 113, 113, 0.4);
+    --dec-edge-selected: #aea6a6;
+    --dec-edge-selected-condition: rgb(59 130 246);
   }
 
   .dec-root .dec-diagram-content {

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -22,6 +22,7 @@ import { SidebarProvider } from "../../../src/components/ui/sidebar";
 import { I18nProvider } from "@serverlessworkflow/i18n";
 import { en } from "../../../src/i18n/locales/en";
 import { ReactFlowProvider, ReactFlow } from "@xyflow/react";
+import * as RF from "@xyflow/react";
 import * as autoLayoutModule from "../../../src/react-flow/diagram/autoLayout";
 
 // Mock ReactFlow to capture props
@@ -179,6 +180,46 @@ describe("Diagram Component", () => {
 
     await waitFor(() => {
       expect(applyAutoLayoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("onEdgesChange with zIndex updates", () => {
+    it("should provide onEdgesChange callback to ReactFlow", async () => {
+      renderDiagram({ isReadOnly: false });
+
+      // Wait for initial render
+      await waitFor(() => {
+        expect(applyAutoLayoutSpy).toHaveBeenCalled();
+      });
+
+      // Get the onEdgesChange callback from ReactFlow mock
+      const mockReactFlow = vi.mocked(ReactFlow);
+      const lastCall = mockReactFlow.mock.calls.at(-1);
+      expect(lastCall).toBeDefined();
+      const reactFlowProps = lastCall![0];
+      const onEdgesChange = reactFlowProps.onEdgesChange;
+
+      expect(onEdgesChange).toBeDefined();
+      expect(typeof onEdgesChange).toBe("function");
+    });
+
+    it("should apply zIndex correctly when edges are updated", () => {
+      // Test the zIndex mapping logic directly
+      const mockEdges: RF.Edge[] = [
+        { id: "edge1", source: "n1", target: "n2", selected: true },
+        { id: "edge2", source: "n2", target: "n3", selected: false },
+        { id: "edge3", source: "n3", target: "n4", selected: true },
+      ];
+
+      // Apply the same logic as in onEdgesChange
+      const updatedEdges = mockEdges.map((edge) => ({
+        ...edge,
+        zIndex: edge.selected ? 1000 : 0,
+      }));
+
+      expect(updatedEdges[0].zIndex).toBe(1000);
+      expect(updatedEdges[1].zIndex).toBe(0);
+      expect(updatedEdges[2].zIndex).toBe(1000);
     });
   });
 });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -219,12 +219,19 @@ describe("Diagram Component", () => {
         expect(lastCall).toBeDefined();
         expect(lastCall![0].edges).toHaveLength(2);
       });
+
       const onEdgesChange = vi.mocked(ReactFlow).mock.calls.at(-1)![0].onEdgesChange;
+      const changes: Parameters<RF.OnEdgesChange>[0] = [
+        { id: "edge1", type: "select", selected: true },
+      ];
+
       act(() => {
-        onEdgesChange?.([{ id: "edge1", type: "select", selected: true }] as any);
+        onEdgesChange?.(changes);
       });
+
       await waitFor(() => {
         const edges = vi.mocked(ReactFlow).mock.calls.at(-1)![0].edges!;
+
         expect(edges.find((e: RF.Edge) => e.id === "edge1")?.zIndex).toBe(1000);
         expect(edges.find((e: RF.Edge) => e.id === "edge2")?.zIndex).toBe(1000);
       });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import { vi, it, expect, afterEach, describe, beforeEach } from "vitest";
 import { Diagram } from "../../../src/react-flow/diagram/Diagram";
 import { DiagramEditorContextProvider } from "../../../src/store/DiagramEditorContextProvider";
@@ -220,7 +220,9 @@ describe("Diagram Component", () => {
         expect(lastCall![0].edges).toHaveLength(2);
       });
       const onEdgesChange = vi.mocked(ReactFlow).mock.calls.at(-1)![0].onEdgesChange;
-      onEdgesChange?.([{ id: "edge1", type: "select", selected: true }] as any);
+      act(() => {
+        onEdgesChange?.([{ id: "edge1", type: "select", selected: true }] as any);
+      });
       await waitFor(() => {
         const edges = vi.mocked(ReactFlow).mock.calls.at(-1)![0].edges!;
         expect(edges.find((e: RF.Edge) => e.id === "edge1")?.zIndex).toBe(1000);

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/Diagram.test.tsx
@@ -203,23 +203,29 @@ describe("Diagram Component", () => {
       expect(typeof onEdgesChange).toBe("function");
     });
 
-    it("should apply zIndex correctly when edges are updated", () => {
-      // Test the zIndex mapping logic directly
-      const mockEdges: RF.Edge[] = [
-        { id: "edge1", source: "n1", target: "n2", selected: true },
-        { id: "edge2", source: "n2", target: "n3", selected: false },
-        { id: "edge3", source: "n3", target: "n4", selected: true },
-      ];
+    it("should apply zIndex correctly when edges are updated", async () => {
+      applyAutoLayoutSpy.mockResolvedValueOnce({
+        nodes: [],
+        edges: [
+          { id: "edge1", source: "n1", target: "n2", selected: false },
+          { id: "edge2", source: "n2", target: "n3", selected: true },
+        ],
+      });
 
-      // Apply the same logic as in onEdgesChange
-      const updatedEdges = mockEdges.map((edge) => ({
-        ...edge,
-        zIndex: edge.selected ? 1000 : 0,
-      }));
+      renderDiagram({ isReadOnly: false });
 
-      expect(updatedEdges[0].zIndex).toBe(1000);
-      expect(updatedEdges[1].zIndex).toBe(0);
-      expect(updatedEdges[2].zIndex).toBe(1000);
+      await waitFor(() => {
+        const lastCall = vi.mocked(ReactFlow).mock.calls.at(-1);
+        expect(lastCall).toBeDefined();
+        expect(lastCall![0].edges).toHaveLength(2);
+      });
+      const onEdgesChange = vi.mocked(ReactFlow).mock.calls.at(-1)![0].onEdgesChange;
+      onEdgesChange?.([{ id: "edge1", type: "select", selected: true }] as any);
+      await waitFor(() => {
+        const edges = vi.mocked(ReactFlow).mock.calls.at(-1)![0].edges!;
+        expect(edges.find((e: RF.Edge) => e.id === "edge1")?.zIndex).toBe(1000);
+        expect(edges.find((e: RF.Edge) => e.id === "edge2")?.zIndex).toBe(1000);
+      });
     });
   });
 });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
@@ -67,6 +67,120 @@ describe("React Flow custom edge types", () => {
     expect(path).toHaveClass(`edge-line ${edgeClass}`);
   });
 
+  it.each([
+    {
+      component: DefaultEdge,
+      edgeDescription: "default",
+      edgeClass: "",
+      selected: true,
+      description: "renders $edgeDescription edge with selected class when selected=true",
+      shouldHaveSelected: true,
+      expectedClasses: "edge-line selected",
+    },
+    {
+      component: ErrorEdge,
+      edgeDescription: "error",
+      edgeClass: "error",
+      selected: true,
+      description: "renders $edgeDescription edge with selected class when selected=true",
+      shouldHaveSelected: true,
+      expectedClasses: "edge-line error selected",
+    },
+    {
+      component: ConditionEdge,
+      edgeDescription: "condition",
+      edgeClass: "condition",
+      selected: true,
+      description: "renders $edgeDescription edge with selected class when selected=true",
+      shouldHaveSelected: true,
+      expectedClasses: "edge-line condition selected",
+    },
+    {
+      component: DefaultEdge,
+      edgeDescription: "default",
+      edgeClass: "",
+      selected: false,
+      description: "renders $edgeDescription edge without selected class when selected=false",
+      shouldHaveSelected: false,
+      expectedClasses: "edge-line",
+    },
+    {
+      component: ErrorEdge,
+      edgeDescription: "error",
+      edgeClass: "error",
+      selected: false,
+      description: "renders $edgeDescription edge without selected class when selected=false",
+      shouldHaveSelected: false,
+      expectedClasses: "edge-line error",
+    },
+    {
+      component: ConditionEdge,
+      edgeDescription: "condition",
+      edgeClass: "condition",
+      selected: false,
+      description: "renders $edgeDescription edge without selected class when selected=false",
+      shouldHaveSelected: false,
+      expectedClasses: "edge-line condition",
+    },
+    {
+      component: DefaultEdge,
+      edgeDescription: "default",
+      edgeClass: "",
+      selected: undefined,
+      description:
+        "renders $edgeDescription edge without selected class when selected is undefined",
+      shouldHaveSelected: false,
+      expectedClasses: "edge-line",
+    },
+    {
+      component: ErrorEdge,
+      edgeDescription: "error",
+      edgeClass: "error",
+      selected: undefined,
+      description:
+        "renders $edgeDescription edge without selected class when selected is undefined",
+      shouldHaveSelected: false,
+      expectedClasses: "edge-line error",
+    },
+    {
+      component: ConditionEdge,
+      edgeDescription: "condition",
+      edgeClass: "condition",
+      selected: undefined,
+      description:
+        "renders $edgeDescription edge without selected class when selected is undefined",
+      shouldHaveSelected: false,
+      expectedClasses: "edge-line condition",
+    },
+  ])("$description", ({ component: Component, selected, shouldHaveSelected, expectedClasses }) => {
+    const { container } = render(
+      <RF.ReactFlowProvider>
+        <Component
+          id={"n1-n2"}
+          source={"n1"}
+          target={"n2"}
+          sourceX={0}
+          sourceY={0}
+          targetX={0}
+          targetY={0}
+          sourcePosition={RF.Position.Left}
+          targetPosition={RF.Position.Left}
+          selected={selected}
+        />
+      </RF.ReactFlowProvider>,
+    );
+    const path = container.querySelector("path.edge-line");
+    expect(path).toBeInTheDocument();
+
+    if (shouldHaveSelected) {
+      expect(path).toHaveClass("selected");
+    } else {
+      expect(path).not.toHaveClass("selected");
+    }
+
+    expect(path).toHaveClass(expectedClasses);
+  });
+
   it("matches snapshot with waypoints", () => {
     const { container } = render(
       <RF.ReactFlowProvider>

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
@@ -152,34 +152,37 @@ describe("React Flow custom edge types", () => {
       shouldHaveSelected: false,
       expectedClasses: "edge-line condition",
     },
-  ])("$description", ({ component: Component, selected, shouldHaveSelected, expectedClasses }) => {
-    const { container } = render(
-      <RF.ReactFlowProvider>
-        <Component
-          id={"n1-n2"}
-          source={"n1"}
-          target={"n2"}
-          sourceX={0}
-          sourceY={0}
-          targetX={0}
-          targetY={0}
-          sourcePosition={RF.Position.Left}
-          targetPosition={RF.Position.Left}
-          selected={selected}
-        />
-      </RF.ReactFlowProvider>,
-    );
-    const path = container.querySelector("path.edge-line");
-    expect(path).toBeInTheDocument();
+  ])(
+    "renders $edgeDescription edge with selected=$selected",
+    ({ component: Component, selected, shouldHaveSelected, expectedClasses }) => {
+      const { container } = render(
+        <RF.ReactFlowProvider>
+          <Component
+            id={"n1-n2"}
+            source={"n1"}
+            target={"n2"}
+            sourceX={0}
+            sourceY={0}
+            targetX={0}
+            targetY={0}
+            sourcePosition={RF.Position.Left}
+            targetPosition={RF.Position.Left}
+            selected={selected}
+          />
+        </RF.ReactFlowProvider>,
+      );
+      const path = container.querySelector("path.edge-line");
+      expect(path).toBeInTheDocument();
 
-    if (shouldHaveSelected) {
-      expect(path).toHaveClass("selected");
-    } else {
-      expect(path).not.toHaveClass("selected");
-    }
+      if (shouldHaveSelected) {
+        expect(path).toHaveClass("selected");
+      } else {
+        expect(path).not.toHaveClass("selected");
+      }
 
-    expect(path).toHaveClass(expectedClasses);
-  });
+      expect(path).toHaveClass(expectedClasses);
+    },
+  );
 
   it("matches snapshot with waypoints", () => {
     const { container } = render(


### PR DESCRIPTION
Closes: https://github.com/serverlessworkflow/editor/issues/186

### Summary 
When paths are merged  by the auto-layout, edges may overlap each other making it hard to follow. By selecting an edge it should be possible to clear visualize the whole path of that edge. 

### Changes

  - Brought selected edge to the top by setting a high z-index when an edge is selected and then restoring it when it is deselected. 
  - Preserved edge stroke color on selection.
  - Added shade to the selected edge make its path easy to follow.
  - Added unit tests.
  
<img width="721" height="273" alt="image" src="https://github.com/user-attachments/assets/e7f25af1-8368-4e64-8f98-52dd2410fc67" />
<img width="721" height="273" alt="image" src="https://github.com/user-attachments/assets/c3f6fede-ba41-4678-ae07-496ed29e8482" />
