### PR TITLE
fix #241 - bug: Generated CHANGELOG files are missing Apache license header

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -5,3 +5,19 @@
 ### Minor Changes
 
 - [#154](https://github.com/serverlessworkflow/editor/pull/154) [`a3a4566`](https://github.com/serverlessworkflow/editor/commit/a3a456643c04c38cf9396ea812e2260691426db2) Thanks [@fantonangeli](https://github.com/fantonangeli)! - Setup changeset for first minor release
+
+<!--
+   Copyright 2021-Present The Serverless Workflow Specification Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->

--- a/packages/serverless-workflow-diagram-editor/CHANGELOG.md
+++ b/packages/serverless-workflow-diagram-editor/CHANGELOG.md
@@ -50,3 +50,19 @@
 
 - Updated dependencies [[`a3a4566`](https://github.com/serverlessworkflow/editor/commit/a3a456643c04c38cf9396ea812e2260691426db2)]:
   - @serverlessworkflow/i18n@0.1.0
+
+<!--
+   Copyright 2021-Present The Serverless Workflow Specification Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/241

### Describe the Bug

The release preparation workflow generates package `CHANGELOG.md` files without the Apache license header.
This makes the Apache RAT check fail on release PRs.
See logs [here](https://github.com/serverlessworkflow/editor/actions/runs/28872517769/job/85638776695):
```

Run APACHE_RAT_JAR="${RUNNER_TEMP:-/tmp}/apache-rat-${APACHE_RAT_VERSION}.jar"
❌ Apache RAT check FAILED - Files with unapproved licenses found:

! /packages/i18n/CHANGELOG.md
! /packages/serverless-workflow-diagram-editor/CHANGELOG.md
Error: Process completed with exit code 1.
```

### Steps to reproduce

1. Run the release preparation workflow: https://github.com/serverlessworkflow/editor/actions/workflows/prepare-release.yaml
2. Open the generated release PR.
3. Check the `CI :: License headers` job.

### Expected Behavior

Generated `CHANGELOG.md` files should include the Apache license header and pass the Apache RAT check.

### Solution

I could not find a changeset option to prepend the license text in the CHANGELOG.
I tried locally adding the license before and after the package name, but that text was partially replaced or moved down with the version.
Adding the license to the bottom generated a correct changelog locally and the license was kept at the bottom as expected.
This should be ok for RAT, otherwise we can add the changelogs in `.rat-excludes`