### PR TITLE
feat: Review and increase E2E test coverage

### DIFF
--- a/.changeset/e2e-tests.md
+++ b/.changeset/e2e-tests.md
@@ -2,4 +2,4 @@
 "@serverlessworkflow/diagram-editor": minor
 ---
 
-Adding more e2e tests
+Test: expand Playwright E2E coverage for diagram rendering and validation errors

--- a/.changeset/e2e-tests.md
+++ b/.changeset/e2e-tests.md
@@ -1,5 +1,0 @@
----
-"@serverlessworkflow/diagram-editor": minor
----
-
-Test: Expand Playwright E2E coverage for diagram rendering and validation errors

--- a/.changeset/e2e-tests.md
+++ b/.changeset/e2e-tests.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": minor
+---
+
+Adding more e2e tests

--- a/.changeset/e2e-tests.md
+++ b/.changeset/e2e-tests.md
@@ -2,4 +2,4 @@
 "@serverlessworkflow/diagram-editor": minor
 ---
 
-Test: expand Playwright E2E coverage for diagram rendering and validation errors
+Test: Expand Playwright E2E coverage for diagram rendering and validation errors

--- a/packages/open-workflow-diagram-editor/tests-e2e/conditional-task.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/conditional-task.spec.ts
@@ -29,7 +29,5 @@ test("diagram editor renders conditional task", async ({ page }) => {
 
   await expect(page.locator(".edge-label")).toContainText(".customer.age < 18");
 
-  await expect(page.getByText("raiseErrorIfUnderage")).toBeVisible();
-
   await expect(page.getByText("RAISE", { exact: true })).toBeVisible();
 });

--- a/packages/open-workflow-diagram-editor/tests-e2e/conditional-task.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/conditional-task.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test("diagram editor renders conditional task", async ({ page }) => {
+  await page.goto("/iframe.html?id=examples-workflows--conditional-task");
+
+  await expect(page.getByTestId("react-flow-canvas")).toBeVisible();
+
+  await expect(page.getByTestId("start-node-root-entry-node")).toBeVisible();
+
+  await expect(page.getByTestId("end-node-root-exit-node")).toBeVisible();
+
+  await expect(page.getByText("raiseErrorIfUnderage")).toBeVisible();
+
+  await expect(page.locator(".edge-label")).toContainText(".customer.age < 18");
+
+  await expect(page.getByText("raiseErrorIfUnderage")).toBeVisible();
+
+  await expect(page.getByText("RAISE", { exact: true })).toBeVisible();
+});

--- a/packages/open-workflow-diagram-editor/tests-e2e/for-loop.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/for-loop.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from "@playwright/test";
 
-test("diagram editor renders for loop workflow", async ({ page }) => {
+test("diagram editor renders for loop workflow ", async ({ page }) => {
   await page.goto("/iframe.html?id=examples-workflows--for");
 
   const forNode = page.getByTestId("for-node-/do/0/checkup");

--- a/packages/open-workflow-diagram-editor/tests-e2e/for-loop.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/for-loop.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test("diagram editor renders conditional task", async ({ page }) => {
+  await page.goto("/iframe.html?id=examples-workflows--for");
+
+  const forNode = page.getByTestId("for-node-/do/0/checkup");
+
+  await expect(forNode).toBeVisible();
+
+  await expect(forNode).toContainText("checkup");
+
+  await expect(forNode).toContainText("FOR");
+
+  await expect(page.getByTestId("for-node-/do/0/checkup-badge")).toHaveText("while");
+
+  const listenNode = page.getByTestId("listen-node-/do/0/checkup/for/do/0/waitForCheckup");
+
+  await expect(listenNode).toBeVisible();
+
+  await expect(listenNode).toContainText("waitForCheckup");
+
+  await expect(listenNode).toContainText("LISTEN");
+
+  await expect(
+    page.getByTestId("listen-node-/do/0/checkup/for/do/0/waitForCheckup-badge"),
+  ).toHaveText("one");
+});

--- a/packages/open-workflow-diagram-editor/tests-e2e/for-loop.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/for-loop.spec.ts
@@ -16,7 +16,7 @@
 
 import { test, expect } from "@playwright/test";
 
-test("diagram editor renders conditional task", async ({ page }) => {
+test("diagram editor renders for loop workflow", async ({ page }) => {
   await page.goto("/iframe.html?id=examples-workflows--for");
 
   const forNode = page.getByTestId("for-node-/do/0/checkup");

--- a/packages/open-workflow-diagram-editor/tests-e2e/forever-foreach.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/forever-foreach.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test("renders listen node with validation error", async ({ page }) => {
+  await page.goto("/iframe.html?id=examples-workflows--listen-to-any-forever-foreach");
+
+  const node = page.getByTestId("listen-node-/do/0/listenToGossips");
+
+  await expect(node).toContainText("listenToGossips");
+  await expect(node).toContainText("LISTEN");
+
+  await expect(page.getByTestId("listen-node-/do/0/listenToGossips-badge")).toHaveText("any");
+
+  await expect(page.getByTestId("listen-node-/do/0/listenToGossips-error")).toBeVisible();
+
+  await expect(node).toHaveClass(/has-error/);
+});

--- a/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
@@ -16,14 +16,14 @@
 
 import { test, expect } from "@playwright/test";
 
-test("renders listen node with document validation error", async ({ page }) => {
+test("renders document validation error in sidebar", async ({ page }) => {
   await page.goto("/iframe.html?id=features-validation-errors--document-error");
 
   const errors = page.getByTestId("sidebar-errors");
   await expect(errors).toBeVisible();
   await expect(
     errors.getByText(
-      "The DSL version of the workflow '9.9.8' does not satisfy the DSL version range supported by this SDK '>=1.0.0 <=1.0.3'.",
+      /The DSL version of the workflow '9\.9\.8' does not satisfy.*supported by this SDK/,
     ),
   ).toBeVisible();
 });

--- a/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test("renders listen node with document validation error", async ({ page }) => {
+  await page.goto("/iframe.html?id=features-validation-errors--document-error");
+
+  const errors = page.getByTestId("sidebar-errors");
+  await expect(errors).toBeVisible();
+  await expect(
+    errors.getByText(
+      "The DSL version of the workflow '9.9.8' does not satisfy the DSL version range supported by this SDK '>=1.0.0 <=1.0.3'.",
+    ),
+  ).toBeVisible();
+});

--- a/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
@@ -23,7 +23,7 @@ test("renders document validation error in sidebar", async ({ page }) => {
   await expect(errors).toBeVisible();
   await expect(
     errors.getByText(
-      /The DSL version of the workflow '9\.9\.8' does not satisfy.*supported by this SDK/,
+      /The DSL version of the workflow '\d\.\d\.\d' does not satisfy.*supported by this SDK/,
     ),
   ).toBeVisible();
 });


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/98

## Description

Expanded the Playwright end-to-end test coverage for workflow diagram rendering and validation scenarios.

### Added diagram rendering tests
- Verify rendering of Start and End nodes.
- Verify rendering of workflow task nodes (e.g. Raise, Listen).
- Verify rendering of container nodes (e.g. For).
- Verify node metadata such as labels, types, and badges.
- Verify diagram edges are rendered correctly.
- Verify validation/error indicators are displayed on nodes when applicable.

### Added validation tests
- Verify document-level validation errors are displayed in the sidebar.
- Verify container-level validation errors are displayed, including:
  - Error count
  - Validation messages
  - Associated field information

## To test it
`run pnpm test-e2e`