### PR TITLE
NO-ISSUE: prepare for the bump to version 1.0.0

### DIFF
--- a/.changeset/release-1-0-0.md
+++ b/.changeset/release-1-0-0.md
@@ -1,0 +1,6 @@
+---
+"@openworkflowspec/diagram-editor": major
+"@openworkflowspec/i18n": major
+---
+
+Release the first stable version under the @openworkflowspec namespace.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openworkflowspec/i18n",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Open workflow internationalization component",
   "keywords": [],
   "homepage": "https://github.com/open-workflow-specification/editor",

--- a/packages/open-workflow-diagram-editor/package.json
+++ b/packages/open-workflow-diagram-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openworkflowspec/diagram-editor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React open workflow diagram component",
   "keywords": [],
   "homepage": "https://github.com/open-workflow-specification/editor",


### PR DESCRIPTION
**Description:**
Prepare the release of `1.0.0` packages, to be handled later from the Release CI:
- Aligns package versions with the already manually published `0.2.0` release on npm.
- Adds a major changeset in preparation for the first stable `1.0.0` release.

If needed, I can also open a GH Issue for this task