### PR TITLE
feat: Increase E2E test timeout to reduce CI flakiness  

### DIFF
--- a/packages/open-workflow-diagram-editor/playwright.config.ts
+++ b/packages/open-workflow-diagram-editor/playwright.config.ts
@@ -19,6 +19,10 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "tests-e2e",
 
+  expect: {
+    timeout: 30000,
+  },
+
   use: {
     baseURL: "http://localhost:6006",
   },


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/273

## Summary

This PR increases the global Playwright assertion timeout from **5 seconds** to **30 seconds** to improve the reliability of end-to-end tests in CI.

## Motivation

Some Playwright E2E tests were intermittently failing in CI because the application and Storybook took longer than the default assertion timeout to render. This resulted in failures such as:

- `diagram editor renders correctly`
- `diagram editor renders conditional task`

with errors like:

```text
expect(locator).toBeVisible() failed
Timeout: 5000ms
Error: element(s) not found
```

These failures were observed only in the slower CI environment and were not reproducible locally.

## Changes

- Added a global Playwright `expect.timeout` of **30 seconds** in `playwright.config.ts`.

```ts
expect: {
  timeout: 30000,
},
```
